### PR TITLE
fix: SSH discovery filtering, selection UX, and pgrep fallback

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -210,20 +210,9 @@ export async function setupCommand(options: SetupOptions = {}): Promise<SetupRes
   // Step 8: Offer to install on remote hosts (only if SSH discovery was enabled)
   if (options.withSshConfig && discoveredHosts.length > 0 && !options.nonInteractive) {
     console.log(chalk.bold('Remote Installation\n'));
-    console.log(chalk.dim('You have SSH access to these hosts. Would you like to install'));
-    console.log(chalk.dim('the agent runner on any of them?\n'));
+    console.log(chalk.dim('  Navigate with ↑↓, press Enter to toggle, scroll down to Confirm or Skip.\n'));
 
-    const { selectedHosts } = await inquirer.prompt<{ selectedHosts: string[] }>([
-      {
-        type: 'checkbox',
-        name: 'selectedHosts',
-        message: 'Select hosts to install on:',
-        choices: discoveredHosts.map((h) => ({
-          name: `${h.name}${h.hostname !== h.name ? ` (${h.hostname})` : ''}`,
-          value: h.name,
-        })),
-      },
-    ]);
+    const selectedHosts = await selectHostsInteractive(discoveredHosts);
 
     if (selectedHosts.length > 0) {
       const installed = await installOnRemoteHosts(selectedHosts, discoveredHosts, apiUrl, relayUrl, verbose);
@@ -718,6 +707,83 @@ async function configureMcpForClaudeCode(): Promise<boolean> {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/**
+ * Interactive host selection using a list prompt with Enter-to-toggle.
+ *
+ * Shows all hosts with ◯/✓ markers. Pressing Enter on a host toggles it.
+ * "Select all" toggles all hosts. "Confirm" and "Skip" at the bottom.
+ * Cursor stays on the same position after each toggle.
+ */
+async function selectHostsInteractive(hosts: DiscoveredHost[]): Promise<string[]> {
+  const selected = new Set<string>();
+  const ACTION_SELECT_ALL = '__select_all__';
+  const ACTION_CONFIRM = '__confirm__';
+  const ACTION_SKIP = '__skip__';
+
+  let cursorIndex = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Build choices with current selection state
+    const choices: Array<{ name: string; value: string } | inquirer.Separator> = [];
+
+    for (const h of hosts) {
+      const marker = selected.has(h.name) ? chalk.green('✓') : chalk.dim('◯');
+      const label = h.hostname !== h.name ? `${h.name} ${chalk.dim(`(${h.hostname})`)}` : h.name;
+      const user = h.user ? chalk.dim(` [${h.user}]`) : '';
+      choices.push({ name: `${marker} ${label}${user}`, value: h.name });
+    }
+
+    choices.push(new inquirer.Separator(chalk.dim('──────────────────')));
+
+    const allSelected = hosts.every((h) => selected.has(h.name));
+    const selectAllLabel = allSelected ? 'Deselect all' : 'Select all';
+    choices.push({ name: chalk.cyan(`◉ ${selectAllLabel}`), value: ACTION_SELECT_ALL });
+
+    choices.push(new inquirer.Separator(chalk.dim('──────────────────')));
+    choices.push({ name: chalk.green(`✔ Confirm (${selected.size} selected)`), value: ACTION_CONFIRM });
+    choices.push({ name: chalk.yellow('✘ Skip'), value: ACTION_SKIP });
+
+    const { choice } = await inquirer.prompt<{ choice: string }>([
+      {
+        type: 'list',
+        name: 'choice',
+        message: `Select hosts to install on:`,
+        choices,
+        pageSize: choices.length,
+        default: cursorIndex,
+      },
+    ]);
+
+    if (choice === ACTION_CONFIRM) {
+      return Array.from(selected);
+    }
+
+    if (choice === ACTION_SKIP) {
+      return [];
+    }
+
+    if (choice === ACTION_SELECT_ALL) {
+      if (allSelected) {
+        selected.clear();
+      } else {
+        for (const h of hosts) selected.add(h.name);
+      }
+      // Keep cursor on Select all
+      cursorIndex = hosts.length + 1; // +1 for separator
+    } else {
+      // Toggle host
+      if (selected.has(choice)) {
+        selected.delete(choice);
+      } else {
+        selected.add(choice);
+      }
+      // Keep cursor on the same host
+      cursorIndex = hosts.findIndex((h) => h.name === choice);
+    }
+  }
+}
 
 function tryOpenUrl(url: string): void {
   const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';

--- a/src/lib/ssh-discovery.ts
+++ b/src/lib/ssh-discovery.ts
@@ -7,6 +7,13 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { SSHHost, DiscoveredHost } from '../types.js';
 
+/** Hostnames that are git forges / not compute machines — auto-skipped */
+const GIT_FORGE_HOSTS = new Set([
+  'github.com', 'gitlab.com', 'bitbucket.org',
+  'ssh.github.com', 'altssh.gitlab.com',
+  'ssh.dev.azure.com', 'vs-ssh.visualstudio.com',
+]);
+
 /**
  * Parse SSH config file and extract host configurations
  */
@@ -37,10 +44,16 @@ async function parseSSHConfig(): Promise<SSHHost[]> {
       const keyLower = key?.toLowerCase();
 
       if (keyLower === 'host') {
-        // Save previous host if exists
+        // Save previous host if valid
         if (currentHost) {
-          hosts.push(currentHost);
-          console.log(`[ssh-discovery] ✓ Added host: ${currentHost.name} (${currentHost.hostname})`);
+          const hn = currentHost.hostname.toLowerCase();
+          if (hn === 'localhost' || hn === '127.0.0.1' || GIT_FORGE_HOSTS.has(hn)) {
+            console.log(`[ssh-discovery] ⊗ Skipped non-compute host: ${currentHost.name} (${currentHost.hostname})`);
+            skippedCount++;
+          } else {
+            hosts.push(currentHost);
+            console.log(`[ssh-discovery] ✓ Added host: ${currentHost.name} (${currentHost.hostname})`);
+          }
         }
 
         const hostPattern = value?.trim() ?? '';
@@ -63,9 +76,11 @@ async function parseSSHConfig(): Promise<SSHHost[]> {
         };
       } else if (currentHost && value) {
         switch (keyLower) {
-          case 'hostname':
-            currentHost.hostname = value.trim();
+          case 'hostname': {
+            // Strip inline comments (e.g., "1.2.3.4  # my server" → "1.2.3.4")
+            currentHost.hostname = value.trim().replace(/\s+#.*$/, '');
             break;
+          }
           case 'user':
             currentHost.user = value.trim();
             break;
@@ -82,10 +97,16 @@ async function parseSSHConfig(): Promise<SSHHost[]> {
       }
     }
 
-    // Don't forget the last host
+    // Don't forget the last host (same validation)
     if (currentHost) {
-      hosts.push(currentHost);
-      console.log(`[ssh-discovery] ✓ Added host: ${currentHost.name} (${currentHost.hostname})`);
+      const hn = currentHost.hostname.toLowerCase();
+      if (hn === 'localhost' || hn === '127.0.0.1' || GIT_FORGE_HOSTS.has(hn)) {
+        console.log(`[ssh-discovery] ⊗ Skipped non-compute host: ${currentHost.name} (${currentHost.hostname})`);
+        skippedCount++;
+      } else {
+        hosts.push(currentHost);
+        console.log(`[ssh-discovery] ✓ Added host: ${currentHost.name} (${currentHost.hostname})`);
+      }
     }
 
     console.log(`[ssh-discovery] Parsed ${hosts.length} valid hosts (skipped ${skippedCount} wildcards/localhost)`);
@@ -211,6 +232,11 @@ async function parseKnownHosts(): Promise<string[]> {
 
         // Skip hashed hostnames (start with |)
         if (hostname.startsWith('|')) {
+          continue;
+        }
+
+        // Skip git forges
+        if (GIT_FORGE_HOSTS.has(hostname.toLowerCase())) {
           continue;
         }
 


### PR DESCRIPTION
## Summary

**SSH discovery filtering** (`ssh-discovery.ts`):
## Test plan
- [ ] Verify github.com, k8s-pod (localhost), and cisco (placeholder hostname with inline comment) are filtered out
- [ ] Verify Enter toggles ◯/✓ on hosts
- [ ] Verify "Select all" toggles all hosts, then toggles back to "Deselect all"
- [ ] Verify cursor stays on same item after toggle
- [ ] Verify "Skip" returns empty selection
- [ ] Verify "Confirm" returns selected hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)