### PR TITLE
fix: remote agent start reliability and progress visibility

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -428,14 +428,13 @@ program
             logLevel: options.logLevel,
             preserveWorktrees: options.preserveWorktrees,
           },
-          options.verbose ? (host, msg) => console.log(chalk.dim(`  [${host}] ${msg}`)) : () => {},
+          (host, msg) => console.log(chalk.dim(`  [${host}] ${msg}`)),
         );
 
         // Report results
         for (const r of results) {
           if (r.success) {
-            const tag = r.alreadyRunning ? 'already running' : 'started';
-            console.log(chalk.green(`  ✓ ${r.host.name}: ${tag}`));
+            console.log(chalk.green(`  ✓ ${r.host.name}: started`));
           } else {
             console.log(chalk.red(`  ✗ ${r.host.name}: ${r.message}`));
           }

--- a/src/lib/ssh-installer.ts
+++ b/src/lib/ssh-installer.ts
@@ -249,23 +249,10 @@ export async function startRemoteAgents(
   const log = (host: string, msg: string) => onProgress?.(host, msg);
 
   for (const host of hosts) {
-    log(host.name, 'Checking for running agent...');
-
-    // 1. Check if already running (pgrep with ps aux fallback) and stop stale process
-    try {
-      const { stdout } = await sshExec(
-        host,
-        'pgrep -f "astro-agent start" 2>/dev/null || ps aux 2>/dev/null | grep "astro-agent start" | grep -v grep',
-      );
-      if (stdout.trim()) {
-        log(host.name, 'Stopping existing agent...');
-        await sshExec(host, 'pkill -f "astro-agent start" 2>/dev/null || true').catch(() => {});
-        // Wait for process to exit
-        await new Promise((r) => setTimeout(r, 1000));
-      }
-    } catch {
-      // pgrep returns exit code 1 when no match — that's fine
-    }
+    // 1. Always kill existing agent so we start fresh with latest binary/config.
+    log(host.name, 'Stopping existing agent (if any)...');
+    await sshExec(host, 'pkill -f "astro-agent start" 2>/dev/null || true').catch(() => {});
+    await new Promise((r) => setTimeout(r, 1000));
 
     // 2. Build start command with forwarded options
     // Use full path to avoid PATH resolution issues across different shells (zsh, bash)
@@ -282,32 +269,35 @@ export async function startRemoteAgents(
         host,
         `export PATH="$HOME/.local/bin:$PATH" && mkdir -p $HOME/.astro/logs && nohup ${startCmd} > $HOME/.astro/logs/agent-runner.log 2>&1 & disown`,
       );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      results.push({ host, success: false, message: `Failed to start: ${msg}` });
-      continue;
+    } catch {
+      // nohup + & disown may cause SSH to exit with non-zero even when the
+      // remote process started successfully. We verify via pgrep below.
     }
 
-    // 3. Verify after 2s — use ps aux fallback if pgrep is unavailable
+    // 3. Verify after 2s — use [a]stro-agent bracket trick to prevent grep self-match
+    log(host.name, 'Verifying process started...');
     await new Promise((r) => setTimeout(r, 2000));
     try {
       const { stdout } = await sshExec(
         host,
-        'pgrep -f "astro-agent start" 2>/dev/null || ps aux 2>/dev/null | grep "astro-agent start" | grep -v grep',
+        'pgrep -f "[a]stro-agent start" 2>/dev/null || ps aux | grep "[a]stro-agent start"',
       );
       if (stdout.trim()) {
         log(host.name, 'Agent started successfully');
         results.push({ host, success: true, message: 'Started' });
       } else {
-        // Fallback: check log tail
+        // Fallback: check log tail for error details
         try {
           const { stdout: logTail } = await sshExec(host, 'tail -5 $HOME/.astro/logs/agent-runner.log 2>/dev/null');
+          log(host.name, `Process not found. Log tail: ${logTail.trim()}`);
           results.push({ host, success: false, message: `Process not found after start. Log tail:\n${logTail}` });
         } catch {
+          log(host.name, 'Process not found (no logs available)');
           results.push({ host, success: false, message: 'Process not found after start (no logs available)' });
         }
       }
     } catch {
+      log(host.name, 'Could not verify (pgrep failed)');
       results.push({ host, success: false, message: 'Could not verify agent start (pgrep failed)' });
     }
   }


### PR DESCRIPTION
## Summary

Fixes three subtle bugs in `startRemoteAgents` that caused remote machines to appear offline or report misleading status on the web portal:

- **pgrep self-match false positive**: `pgrep -f "astro-agent start"` matched the SSH command's own process, so machines with no agent were reported as "already running" and skipped. Fix: unconditionally kill any existing agent and start fresh, ensuring latest binary and tokens are always used.

- **nohup exit code false negative**: `nohup cmd & disown` over SSH returns non-zero even when the remote process starts successfully. The old code treated this as a fatal error and skipped verification. Fix: ignore the SSH exit code and rely solely on the pgrep verification 2 seconds later.

- **Silent progress during slow operations**: `onProgress` was gated behind `--verbose`, so multi-second remote starts showed zero output. Fix: always show step-by-step progress (`[host] Stopping...`, `[host] Starting...`, `[host] Verifying...`).

Additionally, uses `[a]stro-agent` bracket trick in verification pgrep to prevent grep from matching its own process.

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npx vitest run` — 204/204 tests pass
- [x] Manual: `./dist/cli.js launch --force-setup` with 2 remote hosts — both started and verified online on web portal
- [x] Manual: confirmed via `ssh <host> "ps aux | grep '[a]stro-agent'"` that agents are running
- [x] Manual: confirmed via `ssh <host> "tail ~/.astro/logs/agent-runner.log"` that agents connected to relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)