### PR TITLE
fix: worktree control + baseBranch from config

### DIFF
--- a/src/lib/git-pr.ts
+++ b/src/lib/git-pr.ts
@@ -4,6 +4,8 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
@@ -237,6 +239,24 @@ export async function autoCommitChanges(
 }
 
 /**
+ * Read baseBranch from .astro/config.json (set during repo setup).
+ * Returns null if config doesn't exist or baseBranch is not set.
+ */
+async function readBaseBranchFromConfig(gitRoot: string): Promise<string | null> {
+  try {
+    const configPath = join(gitRoot, '.astro', 'config.json');
+    const content = await readFile(configPath, 'utf-8');
+    const config = JSON.parse(content);
+    if (config.baseBranch && typeof config.baseBranch === 'string') {
+      return config.baseBranch;
+    }
+  } catch {
+    // Config doesn't exist or is invalid
+  }
+  return null;
+}
+
+/**
  * Full PR creation flow: auto-commit + push + create PR, with graceful fallbacks
  */
 export async function pushAndCreatePR(
@@ -266,8 +286,8 @@ export async function pushAndCreatePR(
     return result;
   }
 
-  // Get default branch
-  const baseBranch = await getDefaultBranch(gitRoot);
+  // Get default branch: prefer config, fall back to auto-detection
+  const baseBranch = await readBaseBranchFromConfig(gitRoot) ?? await getDefaultBranch(gitRoot);
 
   // Auto-commit any uncommitted changes the agent left behind (opt-in, default true)
   if (options.autoCommit !== false) {

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -748,8 +748,14 @@ export class TaskExecutor {
     branchName?: string;
     cleanup: (options?: { keepBranch?: boolean }) => Promise<void>;
   }> {
+    // Per-task explicit opt-out: user consciously chose to skip worktree
+    if (task.useWorktree === false) {
+      console.log(`[executor] Task ${task.id}: worktree explicitly disabled by user, using raw workdir: ${task.workingDirectory}`);
+      return { workingDirectory: task.workingDirectory, cleanup: async () => {} };
+    }
+
     if (!this.useWorktree) {
-      console.warn(`[executor] Task ${task.id}: worktree disabled, using raw workdir: ${task.workingDirectory}`);
+      console.warn(`[executor] Task ${task.id}: worktree disabled (executor-level), using raw workdir: ${task.workingDirectory}`);
       return { workingDirectory: task.workingDirectory, cleanup: async () => {} };
     }
 
@@ -780,6 +786,9 @@ export class TaskExecutor {
       }
     }
 
+    // Git worktree path — worktree creation must succeed or fail the task.
+    // Running in the raw workdir without isolation risks cross-task commit
+    // contamination and breaks PR creation.
     try {
       console.log(`[executor] Task ${task.id}: creating worktree for workdir=${task.workingDirectory}`);
       const worktree = await createWorktree({
@@ -793,16 +802,15 @@ export class TaskExecutor {
         stderr: stream.stderr,
       });
       if (!worktree) {
-        console.warn(`[executor] Task ${task.id}: createWorktree returned null, falling back to raw workdir: ${task.workingDirectory}`);
-        return { workingDirectory: task.workingDirectory, cleanup: async () => {} };
+        throw new Error(`Worktree creation returned null for ${task.workingDirectory}. Cannot proceed without isolation.`);
       }
       console.log(`[executor] Task ${task.id}: worktree created at ${worktree.workingDirectory} (branch: ${worktree.branchName})`);
       return worktree;
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
-      console.error(`[executor] Task ${task.id}: worktree creation FAILED: ${errorMsg} — falling back to raw workdir: ${task.workingDirectory}`);
-      this.wsClient.sendTaskStatus(task.id, 'running', 0, `Worktree setup failed: ${errorMsg}`);
-      return { workingDirectory: task.workingDirectory, cleanup: async () => {} };
+      console.error(`[executor] Task ${task.id}: worktree creation FAILED: ${errorMsg}`);
+      this.wsClient.sendTaskStatus(task.id, 'failed', 0, `Worktree setup failed: ${errorMsg}`);
+      throw error;
     }
   }
 

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -88,16 +88,23 @@ export async function createWorktree(
     // Non-fatal: proceed with potentially stale refs
   }
 
-  // Detect the default branch to use as start point
-  const defaultBranch = await getDefaultBranch(gitRoot);
+  // Use baseBranch from config (set during repo setup), fall back to auto-detection
+  const defaultBranch = await readBaseBranch(gitRoot, agentDirName) ?? await getDefaultBranch(gitRoot);
 
   // Create worktree from origin/<defaultBranch> — NOT from HEAD.
   // Using HEAD is dangerous because it could be on a stale task branch
   // (from a previous execution that fell back to the repo directly),
   // which would cause cross-task commit contamination.
+  //
+  // If origin/<branch> doesn't exist (purely local repo, no remote),
+  // fall back to the local branch ref.
+  const remoteRef = `origin/${defaultBranch}`;
+  const hasRemoteRef = await refExists(gitRoot, remoteRef);
+  const startPoint = hasRemoteRef ? remoteRef : defaultBranch;
+
   await execFileAsync(
     'git',
-    ['-C', gitRoot, 'worktree', 'add', '-b', branchName, worktreePath, `origin/${defaultBranch}`],
+    ['-C', gitRoot, 'worktree', 'add', '-b', branchName, worktreePath, startPoint],
     { env: withGitEnv(), timeout: 30_000 }
   );
 
@@ -259,6 +266,25 @@ async function getDefaultBranch(gitRoot: string): Promise<string> {
   }
 
   return 'main';
+}
+
+/**
+ * Read the base branch from the agent directory config.
+ * This is set during repo setup (e.g., 'main', 'develop', 'release').
+ * Returns null if config doesn't exist or baseBranch is not set.
+ */
+async function readBaseBranch(gitRoot: string, agentDirName: string): Promise<string | null> {
+  try {
+    const configPath = join(gitRoot, agentDirName, 'config.json');
+    const content = await readFile(configPath, 'utf-8');
+    const config = JSON.parse(content);
+    if (config.baseBranch && typeof config.baseBranch === 'string') {
+      return config.baseBranch;
+    }
+  } catch {
+    // Config doesn't exist or is invalid
+  }
+  return null;
 }
 
 /**
@@ -474,6 +500,18 @@ async function pruneWorktrees(gitRoot: string): Promise<void> {
     });
   } catch {
     // Ignore prune errors
+  }
+}
+
+async function refExists(gitRoot: string, ref: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['-C', gitRoot, 'rev-parse', '--verify', ref], {
+      env: withGitEnv(),
+      timeout: 5_000,
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,9 @@ export interface Task {
 
   /** Worktree strategy for non-git or copy-based execution */
   worktreeStrategy?: 'copy' | 'reference' | 'direct';
+
+  /** Per-task worktree control. When false, skip worktree and run in raw workdir. */
+  useWorktree?: boolean;
 }
 
 export interface TaskResult {


### PR DESCRIPTION
## Summary
- Per-task `useWorktree` opt-out so users can explicitly skip worktree isolation
- Worktree creation fails hard instead of silently falling back to raw workdir (prevents cross-task contamination)
- Read `baseBranch` from `.astro/config.json` instead of only guessing main/master (both `worktree.ts` and `git-pr.ts`)
- Fall back to local branch ref when `origin/<branch>` doesn't exist (supports purely local repos)

## Test plan
- [ ] Dispatch task on git repo — verify worktree created with correct baseBranch from config
- [ ] Dispatch with `useWorktree: false` — verify agent runs in raw workdir
- [ ] Simulate worktree failure (e.g., no commits) — verify task fails with clear error
- [ ] Test on repo with non-standard default branch (e.g., `develop`) — verify correct branch used
- [ ] Test on purely local repo (no remote) — verify local branch ref used as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)