### PR TITLE
feat: multimodal image dispatch and non-git directory support (#16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astroanywhere/agent",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astroanywhere/agent",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "BSL-1.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { spawn, execFileSync, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFileSync, readdirSync, existsSync, writeFileSync, mkdirSync, unlinkSync, openSync, closeSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, statSync, writeFileSync, mkdirSync, unlinkSync, openSync, closeSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -405,6 +405,51 @@ export async function startCommand(options: StartOptions = {}): Promise<void> {
       } catch (error) {
         log('warn', `Failed to list files in ${path}: ${error instanceof Error ? error.message : String(error)}`, logLevel);
         wsClient.sendFileListResponse(correlationId, []);
+      }
+    },
+    onDirectoryList: (path: string, correlationId: string) => {
+      log('debug', `Directory list request for path: ${path || '~'}`, logLevel);
+      try {
+        const resolvedPath = path === '~' || !path ? homedir() : path;
+        const homeDir = homedir();
+
+        if (!existsSync(resolvedPath)) {
+          wsClient.sendDirectoryListResponse(correlationId, resolvedPath, [], 'Directory does not exist', homeDir);
+          return;
+        }
+
+        const stat = statSync(resolvedPath);
+        if (!stat.isDirectory()) {
+          wsClient.sendDirectoryListResponse(correlationId, resolvedPath, [], 'Not a directory', homeDir);
+          return;
+        }
+
+        const dirents = readdirSync(resolvedPath, { withFileTypes: true });
+        const entries = dirents
+          .filter(d => !d.name.startsWith('.'))
+          .map(d => {
+            const fullPath = join(resolvedPath, d.name);
+            let isDirectory = d.isDirectory();
+            let isSymlink = d.isSymbolicLink();
+            // Resolve symlinks to check if they point to directories
+            if (isSymlink) {
+              try {
+                const realStat = statSync(fullPath);
+                isDirectory = realStat.isDirectory();
+              } catch {
+                // Broken symlink
+              }
+            }
+            return { name: d.name, path: fullPath, isDirectory, isSymlink };
+          })
+          .filter(e => e.isDirectory)
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        wsClient.sendDirectoryListResponse(correlationId, resolvedPath, entries, undefined, homeDir);
+        log('debug', `Sent ${entries.length} directories for path: ${resolvedPath}`, logLevel);
+      } catch (error) {
+        log('warn', `Failed to list directories in ${path}: ${error instanceof Error ? error.message : String(error)}`, logLevel);
+        wsClient.sendDirectoryListResponse(correlationId, path || '~', [], `Failed: ${error instanceof Error ? error.message : String(error)}`, homedir());
       }
     },
     onSlashCommands: (correlationId: string, workingDirectory?: string) => {

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared image utilities for multimodal dispatch.
+ *
+ * Used by both Claude SDK and Codex adapters to write task-attached images
+ * to disk and clean them up after execution.
+ */
+
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join, sep, resolve } from 'node:path';
+import type { ImageAttachment } from '../types.js';
+
+/** Safe MIME → file extension mapping. Unknown types fall back to 'png'. */
+const MIME_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/bmp': 'bmp',
+  'image/tiff': 'tiff',
+};
+
+/**
+ * Write task-attached images to a temp directory on disk.
+ *
+ * Returns the list of written file paths (for cleanup or CLI flags).
+ * Sanitizes filenames to prevent path traversal from network-sourced data.
+ */
+export async function writeImagesToDir(
+  images: ImageAttachment[],
+  imageDir: string,
+): Promise<string[]> {
+  await mkdir(imageDir, { recursive: true });
+  const resolvedDir = resolve(imageDir);
+  const paths: string[] = [];
+
+  for (const img of images) {
+    const ext = MIME_EXT[img.mimeType] ?? 'png';
+    // Sanitize filename: strip path separators to prevent traversal
+    const rawName = img.filename ?? `image-${img.blobId}.${ext}`;
+    const safeName = rawName.replace(/[/\\]/g, '_');
+    const filepath = resolve(join(imageDir, safeName));
+
+    // Verify the resolved path is still inside imageDir
+    if (!filepath.startsWith(resolvedDir + sep) && filepath !== resolvedDir) {
+      console.warn(`[image-utils] Skipping image with unsafe filename: ${img.filename}`);
+      continue;
+    }
+
+    await writeFile(filepath, Buffer.from(img.data, 'base64'));
+    paths.push(filepath);
+  }
+
+  return paths;
+}
+
+/**
+ * Remove temp image files. Errors are silently ignored (best-effort cleanup).
+ */
+export async function cleanupImages(paths: string[]): Promise<void> {
+  await Promise.all(paths.map(p => rm(p, { force: true }).catch(() => {})));
+}

--- a/src/lib/repo-utils.ts
+++ b/src/lib/repo-utils.ts
@@ -270,9 +270,8 @@ function ensureAgentDir(workingDir: string, source: ProjectSource, deliveryMode:
     }, null, 2) + '\n', 'utf-8');
   }
 
-  // Add agent dir entries to .gitignore
-  addToGitignore(workingDir, `${agentDirName}/worktrees/`);
-  addToGitignore(workingDir, `${agentDirName}/cache/`);
+  // Add entire agent dir to .gitignore (worktrees, cache, images, config all live here)
+  addToGitignore(workingDir, `${agentDirName}/`);
 
   return agentDirName;
 }

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -16,6 +16,7 @@ import { pushAndCreatePR } from './git-pr.js';
 import {
   checkWorkdirSafety,
   isGitAvailable,
+  isGitRepo,
   createSandbox,
   WorkdirSafetyTier,
   type SafetyCheckResult,
@@ -795,6 +796,14 @@ export class TaskExecutor {
         console.error(`[executor] Task ${task.id}: copy worktree failed: ${errorMsg}, using raw workdir`);
         return { workingDirectory: task.workingDirectory, cleanup: async () => {} };
       }
+    }
+
+    // Non-git directory: fall back to direct execution (no worktree possible).
+    // The safety check (checkWorkdirSafety) already handles blocking parallel
+    // execution in non-git dirs, so single-task direct execution is safe here.
+    if (this.gitAvailable && !(await isGitRepo(task.workingDirectory))) {
+      console.warn(`[executor] Task ${task.id}: not a git repo (${task.workingDirectory}), falling back to direct execution`);
+      return { workingDirectory: task.workingDirectory, cleanup: async () => {} };
     }
 
     // Git worktree path — worktree creation must succeed or fail the task.

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -31,6 +31,8 @@ import type {
   ErrorMessage,
   FileListRequestMessage,
   FileListResponseMessage,
+  DirectoryListRequestMessage,
+  DirectoryListResponseMessage,
   RepoSetupRequestMessage,
   RepoSetupResponseMessage,
   SlashCommandsRequestMessage,
@@ -75,6 +77,7 @@ export interface WebSocketClientOptions {
   onTaskSteer?: (taskId: string, message: string, action?: string, interrupt?: boolean) => void;
   onTaskSafetyDecision?: (taskId: string, decision: 'proceed' | 'init-git' | 'sandbox' | 'cancel') => void;
   onFileList?: (path: string, correlationId: string) => void;
+  onDirectoryList?: (path: string, correlationId: string) => void;
   onRepoSetup?: (payload: RepoSetupRequestMessage['payload']) => void;
   onSlashCommands?: (correlationId: string, workingDirectory?: string) => void;
   onRepoDetect?: (payload: RepoDetectRequestMessage['payload']) => void;
@@ -94,6 +97,7 @@ type IncomingMessage =
   | TaskSafetyDecisionMessage
   | ConfigUpdateMessage
   | FileListRequestMessage
+  | DirectoryListRequestMessage
   | RepoSetupRequestMessage
   | SlashCommandsRequestMessage
   | RepoDetectRequestMessage
@@ -125,6 +129,7 @@ export class WebSocketClient {
   private onTaskSteer?: (taskId: string, message: string, action?: string, interrupt?: boolean) => void;
   private onTaskSafetyDecision?: (taskId: string, decision: 'proceed' | 'init-git' | 'sandbox' | 'cancel') => void;
   private onFileList?: (path: string, correlationId: string) => void;
+  private onDirectoryList?: (path: string, correlationId: string) => void;
   private onRepoSetup?: (payload: RepoSetupRequestMessage['payload']) => void;
   private onSlashCommands?: (correlationId: string, workingDirectory?: string) => void;
   private onRepoDetect?: (payload: RepoDetectRequestMessage['payload']) => void;
@@ -145,6 +150,7 @@ export class WebSocketClient {
     this.onTaskSteer = options.onTaskSteer;
     this.onTaskSafetyDecision = options.onTaskSafetyDecision;
     this.onFileList = options.onFileList;
+    this.onDirectoryList = options.onDirectoryList;
     this.onRepoSetup = options.onRepoSetup;
     this.onSlashCommands = options.onSlashCommands;
     this.onRepoDetect = options.onRepoDetect;
@@ -632,6 +638,20 @@ export class WebSocketClient {
         return;
       }
 
+      // Handle directory_list.request (dot notation from relay)
+      if (raw.type === 'directory_list.request') {
+        const dirListMsg: DirectoryListRequestMessage = {
+          type: 'directory_list_request',
+          timestamp: raw.timestamp as string ?? new Date().toISOString(),
+          payload: {
+            path: raw.path as string ?? (raw.payload as { path?: string })?.path ?? '~',
+            correlationId: raw.correlationId as string ?? (raw.payload as { correlationId?: string })?.correlationId ?? '',
+          },
+        };
+        this.handleDirectoryListRequest(dirListMsg);
+        return;
+      }
+
       // Handle slash_commands.request (dot notation from relay)
       if (raw.type === 'slash_commands.request') {
         const slashMsg: SlashCommandsRequestMessage = {
@@ -725,6 +745,9 @@ export class WebSocketClient {
         break;
       case 'file_list_request':
         this.handleFileListRequest(message as FileListRequestMessage);
+        break;
+      case 'directory_list_request':
+        this.handleDirectoryListRequest(message as DirectoryListRequestMessage);
         break;
       case 'repo_setup_request':
         this.handleRepoSetupRequest(message as RepoSetupRequestMessage);
@@ -829,6 +852,29 @@ export class WebSocketClient {
       type: 'file_list_response',
       timestamp: new Date().toISOString(),
       payload: { correlationId, files },
+    };
+    this.send(msg);
+  }
+
+  private handleDirectoryListRequest(message: DirectoryListRequestMessage): void {
+    const { path, correlationId } = message.payload;
+    this.onDirectoryList?.(path, correlationId);
+  }
+
+  /**
+   * Send directory list response
+   */
+  sendDirectoryListResponse(
+    correlationId: string,
+    path: string,
+    entries: DirectoryListResponseMessage['payload']['entries'],
+    error?: string,
+    homeDirectory?: string,
+  ): void {
+    const msg: DirectoryListResponseMessage = {
+      type: 'directory_list_response',
+      timestamp: new Date().toISOString(),
+      payload: { correlationId, path, entries, error, homeDirectory },
     };
     this.send(msg);
   }

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -336,8 +336,7 @@ async function readBranchPrefix(gitRoot: string, agentDirName: string): Promise<
  * Creates `{agentDirName}/worktrees/` inside the git root so worktrees live
  * alongside the project (easy access to untracked data files, no bloat in ~/.astro/).
  *
- * Automatically adds `{agentDirName}/worktrees/` and `{agentDirName}/cache/`
- * to the repo's `.gitignore` if missing.
+ * Automatically adds `{agentDirName}/` to the repo's `.gitignore` if missing.
  *
  * Falls back to `~/.astro/worktrees/{repoName}/` if the git root is read-only.
  */
@@ -345,8 +344,7 @@ async function resolveWorktreeRoot(gitRoot: string, agentDirName: string): Promi
   const worktreesDir = join(gitRoot, agentDirName, 'worktrees');
   try {
     await mkdir(worktreesDir, { recursive: true });
-    await ensureGitignoreEntry(gitRoot, `${agentDirName}/worktrees/`);
-    await ensureGitignoreEntry(gitRoot, `${agentDirName}/cache/`);
+    await ensureGitignoreEntry(gitRoot, `${agentDirName}/`);
     return worktreesDir;
   } catch {
     // Git root is read-only — fall back to home dir

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -10,6 +10,7 @@ import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Task, TaskResult, TaskArtifact } from '../types.js';
+import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
 import type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
 import { buildHpcContext, type HpcContext } from '../lib/hpc-context.js';
 import type { SlurmJobMonitor } from '../lib/slurm-job-monitor.js';
@@ -139,6 +140,13 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       };
     } finally {
       signal.removeEventListener('abort', abortHandler);
+
+      // Clean up temp image files (runs even on abort/error)
+      const imageCleanupPaths = (task as Task & { _imageCleanupPaths?: string[] })._imageCleanupPaths;
+      if (imageCleanupPaths?.length) {
+        cleanupImages(imageCleanupPaths).catch(() => {});
+      }
+
       // Preserve session state for post-completion steering (mirrors server-side behavior).
       // The query generator is exhausted, but the sessionId is kept so `injectMessage()`
       // can still succeed on the SDK side and a `resumeTask()` could be implemented later.
@@ -505,6 +513,26 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     let effectivePrompt = task.prompt;
     if (this.hpcContext?.available) {
       effectivePrompt = this.hpcContext.contextString + '\n\n---\n\n' + task.prompt;
+    }
+
+    // Write images to temp files for multimodal analysis.
+    // The image paths are referenced in the prompt so the agent can view them
+    // (Claude Code's Read tool supports images natively as it is multimodal).
+    // Cleanup is handled by the caller (execute()) via try/finally.
+    if (task.images && task.images.length > 0) {
+      const imageDir = join(task.workingDirectory, '.astro', 'images');
+      try {
+        const imagePaths = await writeImagesToDir(task.images, imageDir);
+        if (imagePaths.length > 0) {
+          const imageList = imagePaths.map((p, i) => `${i + 1}. ${p}`).join('\n');
+          effectivePrompt += `\n\n---\n\n## Attached Images\n\nThe following ${imagePaths.length} image(s) from the task description have been saved to disk. Use the Read tool to view them (it supports images natively):\n${imageList}`;
+          // Store paths on task for cleanup by execute()
+          (task as Task & { _imageCleanupPaths?: string[] })._imageCleanupPaths = imagePaths;
+          console.log(`[claude-sdk] Wrote ${imagePaths.length} image(s) to ${imageDir}`);
+        }
+      } catch (err) {
+        console.warn(`[claude-sdk] Failed to write images to disk:`, err);
+      }
     }
 
     // Add structured output format if requested (e.g., plan generation)

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -8,6 +8,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
 import type { Task, TaskResult, TaskArtifact } from '../types.js';
 import type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
 import { getProvider } from '../lib/providers.js';
@@ -144,11 +145,32 @@ export class CodexAdapter implements ProviderAdapter {
     };
   }
 
-  private runCodex(
+  private async runCodex(
     task: Task,
     stream: TaskOutputStream,
     signal: AbortSignal
   ): Promise<{ exitCode: number; output: string; error?: string; artifacts?: TaskArtifact[]; model?: string }> {
+    // Codex requires --skip-git-repo-check when running outside a git repository.
+    // The task executor already handles git safety at a higher level (worktree creation,
+    // safety checks), so we can safely allow non-git directories here.
+    const isGitRepo = task.workingDirectory
+      && existsSync(join(task.workingDirectory, '.git'));
+
+    // Resolve model: task-level override > config file default
+    const model = task.model || this.configModel;
+
+    // Write images to temp files for the --image flag
+    let imagePaths: string[] = [];
+    if (task.images && task.images.length > 0) {
+      const imageDir = join(task.workingDirectory || homedir(), '.astro', 'images');
+      try {
+        imagePaths = await writeImagesToDir(task.images, imageDir);
+        console.log(`[codex] Wrote ${imagePaths.length} image(s) to ${imageDir}`);
+      } catch (err) {
+        console.warn(`[codex] Failed to write images to disk:`, err);
+      }
+    }
+
     return new Promise((resolve, reject) => {
       // Codex CLI: use `exec` subcommand for non-interactive execution
       // --json: structured JSONL output for parsing
@@ -162,14 +184,14 @@ export class CodexAdapter implements ProviderAdapter {
       // The task executor provides isolation at a higher level (worktree creation,
       // working directory restriction).
 
-      // Codex requires --skip-git-repo-check when running outside a git repository.
-      // The task executor already handles git safety at a higher level (worktree creation,
-      // safety checks), so we can safely allow non-git directories here.
-      const isGitRepo = task.workingDirectory
-        && existsSync(join(task.workingDirectory, '.git'));
-
-      // Resolve model: task-level override > config file default
-      const model = task.model || this.configModel;
+      // Build prompt with image references if images were written to disk.
+      // The --image flag may not be available in all Codex CLI versions,
+      // so we also reference files in the prompt text as a fallback.
+      let effectivePrompt = task.prompt;
+      if (imagePaths.length > 0) {
+        const imageList = imagePaths.map((p, i) => `${i + 1}. ${p}`).join('\n');
+        effectivePrompt += `\n\n---\n\n## Attached Images\n\nThe following ${imagePaths.length} image(s) from the task description have been saved to disk for your analysis:\n${imageList}`;
+      }
 
       const args = [
         'exec',
@@ -177,7 +199,9 @@ export class CodexAdapter implements ProviderAdapter {
         ...(model ? ['-m', model] : []),   // Explicit model selection
         ...(!isGitRepo ? ['--skip-git-repo-check'] : []),
         '--json',                         // JSONL output for structured parsing
-        task.prompt,
+        // Pass images via --image flag if available (Codex CLI feature)
+        ...(imagePaths.length > 0 ? ['--image', imagePaths.join(',')] : []),
+        effectivePrompt,
       ];
 
       const env = {
@@ -261,6 +285,9 @@ export class CodexAdapter implements ProviderAdapter {
 
       proc.on('error', (error) => {
         signal.removeEventListener('abort', abortHandler);
+        if (imagePaths.length > 0) {
+          cleanupImages(imagePaths).catch(() => {});
+        }
         reject(error);
       });
 
@@ -274,6 +301,11 @@ export class CodexAdapter implements ProviderAdapter {
 
         // Also extract artifacts from heuristic patterns in raw output
         this.extractArtifacts(stdout, artifacts);
+
+        // Clean up temp image files
+        if (imagePaths.length > 0) {
+          cleanupImages(imagePaths).catch(() => {});
+        }
 
         resolve({
           exitCode: code ?? 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,22 @@ export interface GpuInfo {
 }
 
 // ============================================================================
+// Image / Multimodal Types
+// ============================================================================
+
+/** Base64-encoded image for multimodal dispatch */
+export interface ImageAttachment {
+  /** Blob ID from the blobs table */
+  blobId: string;
+  /** MIME type (image/png, image/jpeg, etc.) */
+  mimeType: string;
+  /** Base64-encoded image data */
+  data: string;
+  /** Optional filename */
+  filename?: string;
+}
+
+// ============================================================================
 // Task Types
 // ============================================================================
 
@@ -147,6 +163,9 @@ export interface Task {
 
   /** Human-readable task description — used for PR body instead of raw prompt */
   description?: string;
+
+  /** Images embedded in task content, sent as base64 for multimodal prompts */
+  images?: ImageAttachment[];
 }
 
 export interface TaskResult {
@@ -202,6 +221,7 @@ export type WSMessageType =
   | 'task_safety_response'
   | 'resource_update'
   | 'file_list_response'
+  | 'directory_list_response'
   | 'slash_commands_response'
   | 'repo_detect_response'
   | 'branch_list_response'
@@ -216,6 +236,7 @@ export type WSMessageType =
   | 'task_safety_decision'
   | 'config_update'
   | 'file_list_request'
+  | 'directory_list_request'
   | 'repo_setup_request'
   | 'repo_setup_response'
   | 'slash_commands_request'
@@ -479,6 +500,30 @@ export interface FileListResponseMessage extends WSMessage {
   payload: {
     correlationId: string;
     files: string[];
+  };
+}
+
+export interface DirectoryListRequestMessage extends WSMessage {
+  type: 'directory_list_request';
+  payload: {
+    path: string;
+    correlationId: string;
+  };
+}
+
+export interface DirectoryListResponseMessage extends WSMessage {
+  type: 'directory_list_response';
+  payload: {
+    correlationId: string;
+    path: string;
+    entries: Array<{
+      name: string;
+      path: string;
+      isDirectory: boolean;
+      isSymlink?: boolean;
+    }>;
+    error?: string;
+    homeDirectory?: string;
   };
 }
 

--- a/tests/directory-list.test.ts
+++ b/tests/directory-list.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Directory List Request/Response Tests
+ *
+ * Verifies the directory_list_request message handling in the agent runner:
+ *   1. Type definitions — DirectoryListRequestMessage and DirectoryListResponseMessage
+ *   2. WebSocket client — message routing (underscore and dot notation)
+ *   3. WebSocket client — response sending
+ *   4. Start command — onDirectoryList callback (filesystem listing logic)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { existsSync, statSync, readdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type {
+  DirectoryListRequestMessage,
+  DirectoryListResponseMessage,
+} from '../src/types'
+
+// ============================================================================
+// 1. Type definition tests
+// ============================================================================
+
+describe('DirectoryList type definitions', () => {
+  it('DirectoryListRequestMessage has correct shape', () => {
+    const msg: DirectoryListRequestMessage = {
+      type: 'directory_list_request',
+      timestamp: new Date().toISOString(),
+      payload: {
+        path: '/home/user/projects',
+        correlationId: 'corr-123',
+      },
+    }
+
+    expect(msg.type).toBe('directory_list_request')
+    expect(msg.payload.path).toBe('/home/user/projects')
+    expect(msg.payload.correlationId).toBe('corr-123')
+  })
+
+  it('DirectoryListResponseMessage has correct shape with entries', () => {
+    const msg: DirectoryListResponseMessage = {
+      type: 'directory_list_response',
+      timestamp: new Date().toISOString(),
+      payload: {
+        correlationId: 'corr-123',
+        path: '/home/user/projects',
+        entries: [
+          { name: 'src', path: '/home/user/projects/src', isDirectory: true },
+          { name: 'docs', path: '/home/user/projects/docs', isDirectory: true, isSymlink: true },
+        ],
+        homeDirectory: '/home/user',
+      },
+    }
+
+    expect(msg.type).toBe('directory_list_response')
+    expect(msg.payload.entries).toHaveLength(2)
+    expect(msg.payload.entries[0].name).toBe('src')
+    expect(msg.payload.entries[0].isDirectory).toBe(true)
+    expect(msg.payload.entries[1].isSymlink).toBe(true)
+    expect(msg.payload.homeDirectory).toBe('/home/user')
+    expect(msg.payload.error).toBeUndefined()
+  })
+
+  it('DirectoryListResponseMessage supports error field', () => {
+    const msg: DirectoryListResponseMessage = {
+      type: 'directory_list_response',
+      timestamp: new Date().toISOString(),
+      payload: {
+        correlationId: 'corr-456',
+        path: '/nonexistent',
+        entries: [],
+        error: 'Directory does not exist',
+      },
+    }
+
+    expect(msg.payload.entries).toHaveLength(0)
+    expect(msg.payload.error).toBe('Directory does not exist')
+  })
+})
+
+// ============================================================================
+// 2. Message routing tests (simulated)
+// ============================================================================
+
+describe('Directory list message routing', () => {
+  /**
+   * Simulates the WebSocket client's dot-notation normalization logic.
+   * This mirrors the code in websocket-client.ts that converts
+   * 'directory_list.request' to 'directory_list_request'.
+   */
+  function normalizeDotNotation(raw: Record<string, unknown>): DirectoryListRequestMessage | null {
+    if (raw.type === 'directory_list.request') {
+      return {
+        type: 'directory_list_request',
+        timestamp: raw.timestamp as string ?? new Date().toISOString(),
+        payload: {
+          path: raw.path as string ?? (raw.payload as { path?: string })?.path ?? '~',
+          correlationId: raw.correlationId as string ?? (raw.payload as { correlationId?: string })?.correlationId ?? '',
+        },
+      }
+    }
+    return null
+  }
+
+  it('normalizes directory_list.request (dot notation) to directory_list_request', () => {
+    const raw = {
+      type: 'directory_list.request',
+      timestamp: '2025-01-01T00:00:00Z',
+      path: '/home/user',
+      correlationId: 'corr-abc',
+    }
+
+    const normalized = normalizeDotNotation(raw)
+    expect(normalized).not.toBeNull()
+    expect(normalized!.type).toBe('directory_list_request')
+    expect(normalized!.payload.path).toBe('/home/user')
+    expect(normalized!.payload.correlationId).toBe('corr-abc')
+  })
+
+  it('handles dot notation with payload wrapper', () => {
+    const raw = {
+      type: 'directory_list.request',
+      timestamp: '2025-01-01T00:00:00Z',
+      payload: {
+        path: '/tmp',
+        correlationId: 'corr-def',
+      },
+    }
+
+    const normalized = normalizeDotNotation(raw)
+    expect(normalized).not.toBeNull()
+    expect(normalized!.payload.path).toBe('/tmp')
+    expect(normalized!.payload.correlationId).toBe('corr-def')
+  })
+
+  it('defaults path to ~ when not provided', () => {
+    const raw = {
+      type: 'directory_list.request',
+      correlationId: 'corr-ghi',
+    }
+
+    const normalized = normalizeDotNotation(raw)
+    expect(normalized).not.toBeNull()
+    expect(normalized!.payload.path).toBe('~')
+  })
+
+  it('does not normalize non-directory_list messages', () => {
+    const raw = { type: 'file_list.request', path: '/home' }
+    const normalized = normalizeDotNotation(raw)
+    expect(normalized).toBeNull()
+  })
+
+  /**
+   * Simulates the routeMessage switch case to verify directory_list_request
+   * is a recognized message type.
+   */
+  function routeMessage(type: string): string {
+    switch (type) {
+      case 'file_list_request': return 'file_list'
+      case 'directory_list_request': return 'directory_list'
+      case 'repo_setup_request': return 'repo_setup'
+      case 'repo_detect_request': return 'repo_detect'
+      case 'branch_list_request': return 'branch_list'
+      case 'git_init_request': return 'git_init'
+      default: return 'unknown'
+    }
+  }
+
+  it('routes directory_list_request to directory_list handler', () => {
+    expect(routeMessage('directory_list_request')).toBe('directory_list')
+  })
+
+  it('routes file_list_request to file_list handler (not confused)', () => {
+    expect(routeMessage('file_list_request')).toBe('file_list')
+  })
+})
+
+// ============================================================================
+// 3. Response construction tests
+// ============================================================================
+
+describe('Directory list response construction', () => {
+  /**
+   * Simulates WebSocketClient.sendDirectoryListResponse()
+   */
+  function buildResponse(
+    correlationId: string,
+    path: string,
+    entries: DirectoryListResponseMessage['payload']['entries'],
+    error?: string,
+    homeDirectory?: string,
+  ): DirectoryListResponseMessage {
+    return {
+      type: 'directory_list_response',
+      timestamp: new Date().toISOString(),
+      payload: { correlationId, path, entries, error, homeDirectory },
+    }
+  }
+
+  it('builds successful response with entries', () => {
+    const entries = [
+      { name: 'src', path: '/project/src', isDirectory: true },
+      { name: 'tests', path: '/project/tests', isDirectory: true },
+    ]
+    const resp = buildResponse('corr-1', '/project', entries, undefined, '/home/user')
+
+    expect(resp.type).toBe('directory_list_response')
+    expect(resp.payload.correlationId).toBe('corr-1')
+    expect(resp.payload.path).toBe('/project')
+    expect(resp.payload.entries).toHaveLength(2)
+    expect(resp.payload.error).toBeUndefined()
+    expect(resp.payload.homeDirectory).toBe('/home/user')
+  })
+
+  it('builds error response with empty entries', () => {
+    const resp = buildResponse('corr-2', '/nonexistent', [], 'Directory does not exist', '/home/user')
+
+    expect(resp.payload.entries).toHaveLength(0)
+    expect(resp.payload.error).toBe('Directory does not exist')
+  })
+
+  it('builds response for empty directory', () => {
+    const resp = buildResponse('corr-3', '/empty-dir', [])
+
+    expect(resp.payload.entries).toHaveLength(0)
+    expect(resp.payload.error).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// 4. onDirectoryList callback logic tests
+// ============================================================================
+
+describe('onDirectoryList callback logic', () => {
+  /**
+   * Simulates the onDirectoryList handler from start.ts.
+   * Uses the real filesystem to test against actual directories.
+   */
+  function handleDirectoryList(path: string): {
+    resolvedPath: string
+    entries: Array<{ name: string; path: string; isDirectory: boolean; isSymlink?: boolean }>
+    error?: string
+    homeDirectory: string
+  } {
+    const homeDir = homedir()
+    const resolvedPath = path === '~' || !path ? homeDir : path
+
+    if (!existsSync(resolvedPath)) {
+      return { resolvedPath, entries: [], error: 'Directory does not exist', homeDirectory: homeDir }
+    }
+
+    const stat = statSync(resolvedPath)
+    if (!stat.isDirectory()) {
+      return { resolvedPath, entries: [], error: 'Not a directory', homeDirectory: homeDir }
+    }
+
+    const dirents = readdirSync(resolvedPath, { withFileTypes: true })
+    const entries = dirents
+      .filter(d => !d.name.startsWith('.'))
+      .map(d => {
+        const fullPath = join(resolvedPath, d.name)
+        let isDirectory = d.isDirectory()
+        const isSymlink = d.isSymbolicLink()
+        if (isSymlink) {
+          try {
+            const realStat = statSync(fullPath)
+            isDirectory = realStat.isDirectory()
+          } catch {
+            // Broken symlink
+          }
+        }
+        return { name: d.name, path: fullPath, isDirectory, isSymlink }
+      })
+      .filter(e => e.isDirectory)
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    return { resolvedPath, entries, homeDirectory: homeDir }
+  }
+
+  it('resolves ~ to home directory', () => {
+    const result = handleDirectoryList('~')
+    expect(result.resolvedPath).toBe(homedir())
+    expect(result.error).toBeUndefined()
+  })
+
+  it('resolves empty path to home directory', () => {
+    const result = handleDirectoryList('')
+    expect(result.resolvedPath).toBe(homedir())
+  })
+
+  it('returns error for nonexistent path', () => {
+    const result = handleDirectoryList('/this/path/definitely/does/not/exist/abc123xyz')
+    expect(result.entries).toHaveLength(0)
+    expect(result.error).toBe('Directory does not exist')
+  })
+
+  it('lists only directories (no files)', () => {
+    // Use /tmp which should exist on any system and contain some dirs
+    const result = handleDirectoryList('/tmp')
+    if (result.entries.length > 0) {
+      result.entries.forEach(entry => {
+        expect(entry.isDirectory).toBe(true)
+      })
+    }
+    expect(result.error).toBeUndefined()
+  })
+
+  it('filters out hidden directories (starting with .)', () => {
+    const result = handleDirectoryList(homedir())
+    const hiddenEntries = result.entries.filter(e => e.name.startsWith('.'))
+    expect(hiddenEntries).toHaveLength(0)
+  })
+
+  it('entries are sorted alphabetically by name', () => {
+    const result = handleDirectoryList(homedir())
+    if (result.entries.length > 1) {
+      for (let i = 1; i < result.entries.length; i++) {
+        expect(result.entries[i].name.localeCompare(result.entries[i - 1].name)).toBeGreaterThanOrEqual(0)
+      }
+    }
+  })
+
+  it('each entry has name, path, and isDirectory fields', () => {
+    const result = handleDirectoryList(homedir())
+    result.entries.forEach(entry => {
+      expect(entry.name).toBeDefined()
+      expect(typeof entry.name).toBe('string')
+      expect(entry.path).toBeDefined()
+      expect(entry.path).toContain(entry.name)
+      expect(entry.isDirectory).toBe(true)
+    })
+  })
+
+  it('always includes homeDirectory in response', () => {
+    const result1 = handleDirectoryList('~')
+    expect(result1.homeDirectory).toBe(homedir())
+
+    const result2 = handleDirectoryList('/tmp')
+    expect(result2.homeDirectory).toBe(homedir())
+
+    const result3 = handleDirectoryList('/nonexistent')
+    expect(result3.homeDirectory).toBe(homedir())
+  })
+
+  it('returns error when path is a file, not a directory', () => {
+    // /etc/hostname or /etc/hosts should exist as a file on most systems
+    const testFile = existsSync('/etc/hostname') ? '/etc/hostname' : '/etc/hosts'
+    if (existsSync(testFile)) {
+      const result = handleDirectoryList(testFile)
+      expect(result.error).toBe('Not a directory')
+      expect(result.entries).toHaveLength(0)
+    }
+  })
+})
+
+// ============================================================================
+// 5. End-to-end message flow simulation
+// ============================================================================
+
+describe('Directory list end-to-end message flow', () => {
+  it('relay request → agent handler → relay response (full round trip)', () => {
+    // 1. Relay sends directory_list_request
+    const relayRequest = {
+      type: 'directory_list_request' as const,
+      timestamp: new Date().toISOString(),
+      payload: {
+        path: homedir(),
+        correlationId: 'e2e-corr-1',
+      },
+    }
+
+    // 2. Agent handler extracts path and correlationId
+    const { path, correlationId } = relayRequest.payload
+    expect(path).toBe(homedir())
+    expect(correlationId).toBe('e2e-corr-1')
+
+    // 3. Agent lists directory
+    const dirents = readdirSync(path, { withFileTypes: true })
+    const entries = dirents
+      .filter(d => !d.name.startsWith('.') && d.isDirectory())
+      .map(d => ({
+        name: d.name,
+        path: join(path, d.name),
+        isDirectory: true as const,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    // 4. Agent sends response
+    const response: DirectoryListResponseMessage = {
+      type: 'directory_list_response',
+      timestamp: new Date().toISOString(),
+      payload: {
+        correlationId,
+        path,
+        entries,
+        homeDirectory: homedir(),
+      },
+    }
+
+    // 5. Verify response
+    expect(response.type).toBe('directory_list_response')
+    expect(response.payload.correlationId).toBe('e2e-corr-1')
+    expect(response.payload.path).toBe(homedir())
+    expect(response.payload.homeDirectory).toBe(homedir())
+    expect(Array.isArray(response.payload.entries)).toBe(true)
+    response.payload.entries.forEach(entry => {
+      expect(entry.isDirectory).toBe(true)
+      expect(entry.name).not.toMatch(/^\./)
+    })
+  })
+
+  it('relay dot-notation request → normalize → handle → respond', () => {
+    // Relay sends in dot notation format
+    const rawMessage: Record<string, unknown> = {
+      type: 'directory_list.request',
+      timestamp: new Date().toISOString(),
+      path: '/tmp',
+      correlationId: 'e2e-corr-2',
+    }
+
+    // Normalize to underscore format
+    expect(rawMessage.type).toBe('directory_list.request')
+    const normalized: DirectoryListRequestMessage = {
+      type: 'directory_list_request',
+      timestamp: rawMessage.timestamp as string,
+      payload: {
+        path: rawMessage.path as string,
+        correlationId: rawMessage.correlationId as string,
+      },
+    }
+
+    expect(normalized.type).toBe('directory_list_request')
+    expect(normalized.payload.path).toBe('/tmp')
+    expect(normalized.payload.correlationId).toBe('e2e-corr-2')
+  })
+})

--- a/tests/workspace/agent-runner-worktree.test.ts
+++ b/tests/workspace/agent-runner-worktree.test.ts
@@ -133,8 +133,7 @@ describe('agent-runner worktree (real git)', { timeout: 30_000 }, () => {
     const gitignorePath = join(repoDir, '.gitignore');
     expect(existsSync(gitignorePath)).toBe(true);
     const gitignoreContent = readFileSync(gitignorePath, 'utf-8');
-    expect(gitignoreContent).toContain('.astro/worktrees/');
-    expect(gitignoreContent).toContain('.astro/cache/');
+    expect(gitignoreContent).toContain('.astro/');
 
     // Cleanup should remove the worktree directory
     await setup.cleanup();


### PR DESCRIPTION
* feat: add directory_list_request handler for remote directory browsing

The relay server was sending directory_list_request messages to the agent runner, but the agent runner had no handler for them, causing the frontend directory browser to timeout after 10 seconds with no results.



* feat: add multimodal image support to Claude SDK and Codex adapters

Enable agents to see images embedded in task content. Images are received as base64 ImageAttachment objects from the relay and written to temp files.

- Claude SDK adapter: writes images to .astro/images/, references file paths in prompt text for the agent to read with its Read tool
- Codex adapter: writes images to .astro/images/, passes file paths via the native --image CLI flag for direct vision input
- Types: add ImageAttachment interface and images field to Task



* fix: harden multimodal image handling — path traversal, cleanup on abort, shared utility

- Extract shared writeImagesToDir/cleanupImages into src/lib/image-utils.ts
- Sanitize filenames to prevent path traversal from network-sourced data
- Use MIME type allowlist instead of split('/')[1] for file extensions
- Move image cleanup to execute() finally block so abort paths clean up
- Add prompt-text fallback in Codex adapter if --image flag unsupported
- Add cleanup in Codex error handler for spawn failures



* fix: fall back to direct execution in non-git directories



* fix: gitignore entire .astro/ directory instead of individual subdirs

Previously only .astro/worktrees/ and .astro/cache/ were added to .gitignore. This missed other contents like images/ and config.json. Now adds .astro/ to cover everything.



---------