### PR TITLE
fix: AI review feedback — lock timing, symlinks, comments

### DIFF
--- a/src/lib/branch-lock.ts
+++ b/src/lib/branch-lock.ts
@@ -7,6 +7,7 @@
  */
 
 import { resolve } from 'node:path';
+import { realpathSync } from 'node:fs';
 
 export interface BranchLockHandle {
   /** Release the lock. Idempotent — safe to call multiple times. */
@@ -31,11 +32,12 @@ export class BranchLockManager {
    * This is required because each task's auto-merge into the project branch
    * must complete before the next task can branch from the updated tip.
    *
-   * Key format: `{resolvedWorkdir}::{shortProjectId}`
-   * Fallback:   `{resolvedWorkdir}::{taskId}`
+   * Key format: `{canonicalWorkdir}::{shortProjectId}`
+   * Fallback:   `{canonicalWorkdir}::{taskId}`
    *
-   * The workdir prefix scopes locks per repository so different repos
-   * never contend even if they share project IDs.
+   * Uses `realpathSync` to follow symlinks so that the same repo accessed
+   * via different paths (e.g., symlink vs real path) shares the same lock.
+   * Falls back to `resolve()` if the path doesn't exist yet.
    */
   static computeLockKey(
     workdir: string,
@@ -43,9 +45,15 @@ export class BranchLockManager {
     _shortNodeId?: string,
     taskId?: string,
   ): string {
-    const resolvedWorkdir = resolve(workdir);
+    let canonicalWorkdir: string;
+    try {
+      canonicalWorkdir = realpathSync(workdir);
+    } catch {
+      // Path doesn't exist yet (e.g., worktree not created) — fall back to resolve()
+      canonicalWorkdir = resolve(workdir);
+    }
     const suffix = shortProjectId ?? taskId ?? 'unknown';
-    return `${resolvedWorkdir}::${suffix}`;
+    return `${canonicalWorkdir}::${suffix}`;
   }
 
   /**

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -794,27 +794,18 @@ export class TaskExecutor {
         : await this.prepareTaskWorkspace(normalizedTask, stream);
     } catch (prepErr) {
       // Release branch lock on workspace preparation failure to avoid deadlocking
-      // subsequent tasks in the same project (fix from PR #26)
+      // subsequent tasks in the same project (fix from PR #26).
+      // Note: processQueue() is NOT called here — the finally block in the outer
+      // try-catch handles queue draining for all exit paths, avoiding double-dequeue.
       if (branchLock) branchLock.release();
       this.runningTasks.delete(normalizedTask.id);
       this.wsClient.removeActiveTask(normalizedTask.id);
       this.untrackTaskDirectory(task);
-      this.processQueue();
       throw prepErr;
     }
     const taskWithWorkspace = { ...normalizedTask, workingDirectory: prepared.workingDirectory };
     runningTask.task = taskWithWorkspace;
     console.log(`[executor] Task ${task.id}: workspace prepared, cwd=${prepared.workingDirectory}`);
-
-    // Release the branch lock now that the worktree is created.
-    // The lock only needs to be held during worktree creation (branching from the
-    // project branch tip). Once each task has its own worktree, they can execute
-    // in parallel. The merge step (PR creation) has its own serialization.
-    if (branchLock) {
-      branchLock.release();
-      branchLock = undefined;
-      console.log(`[executor] Task ${task.id}: branch lock released after workspace prep`);
-    }
 
     // Execute with timeout
     const timeout = task.timeout ?? this.defaultTimeout;
@@ -1055,6 +1046,14 @@ export class TaskExecutor {
         }
         console.log(`[executor] Task ${task.id}: cleaning up sandbox`);
         await sandbox.cleanup();
+      }
+
+      // Release branch lock after execution + delivery (auto-merge) completes.
+      // The accumulative model requires the lock to be held through auto-merge
+      // so the next task branches from the updated project branch tip.
+      if (branchLock) {
+        branchLock.release();
+        console.log(`[executor] Task ${task.id}: branch lock released after delivery`);
       }
 
       // Untrack task from directory

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -264,8 +264,10 @@ export async function removeLingeringWorktrees(gitRoot: string, branchName: stri
  * If it doesn't exist, create it from origin/{defaultBranch} and push.
  * Idempotent — safe to call on every task dispatch.
  *
- * Note: Safe to race — if multiple tasks call this concurrently, only the
- * first push succeeds; others fail non-fatally on push (branch already exists).
+ * Note: In practice, concurrent calls for the same project are prevented by
+ * the per-project branch lock in task-executor.ts. The function is still
+ * internally idempotent as a secondary safety net — if called concurrently,
+ * only the first push succeeds; others fail non-fatally (branch already exists).
  */
 async function ensureProjectBranch(
   gitRoot: string,


### PR DESCRIPTION
## Summary

Follow-up fixes from AI code review on PR #27. Addresses all reviewer feedback:

- **Branch lock timing**: Reverted early lock release back to `finally` block. The accumulative project branch model requires the lock to be held through auto-merge so the next task branches from the updated project branch tip. Early release would cause Task B to branch from a stale base before Task A's merge completes.
- **Double processQueue()**: Removed `processQueue()` from the workspace-prep catch block. The finally block in the outer try-catch already handles queue draining for all exit paths, preventing double-dequeue.
- **Symlink-safe lock keys**: Changed `resolve()` to `realpathSync()` in `BranchLockManager.computeLockKey()` so symlinked workdirs produce the same canonical key. Falls back to `resolve()` if `realpathSync` fails (e.g., path doesn't exist yet).
- **Worktree comment**: Clarified that `ensureProjectBranch()` is protected primarily by the per-project branch lock, with internal idempotency as a secondary safety net.

## Files Changed

- `src/lib/task-executor.ts` — Lock timing, double-dequeue fix
- `src/lib/branch-lock.ts` — realpathSync for canonical paths
- `src/lib/worktree.ts` — Comment clarification

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Sequential task execution within same project still serializes correctly
- [ ] Workspace prep failure releases lock and doesn't deadlock subsequent tasks

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)