### PR TITLE
fix: pass AWS credentials as env vars for claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,10 +35,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: ${{ secrets.AWS_REGION }}
 
           # Allow Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Summary
- Move AWS credentials from `with:` (action inputs) to `env:` (environment variables)
- `claude-code-action` reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` from env, not inputs

## Context
The previous merge (#33) squashed and lost this fix. The action currently fails with:
> Environment variable validation failed: AWS_REGION is required when using AWS Bedrock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)