### PR TITLE
ci: grant Claude Code git and PR permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -35,6 +35,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
+
+          allowed_tools: |
+            Bash(git submodule *)
+            Bash(git merge *)
+            Bash(git fetch *)
+            Bash(git add *)
+            Bash(git commit *)
+            Bash(git push *)
+            Bash(cd * && git *)
 
           # Allow Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Changed `contents`/`pull-requests`/`issues` permissions from `read` → `write` so Claude can push commits and comment on PRs
- Added `allowed_tools` for git submodule, merge, fetch, add, commit, push, and compound cd+git commands

Companion to [astro#348](https://github.com/fuxialexander/astro/pull/348).

## Test plan
- [ ] Trigger `@claude` on a PR and verify it can run git operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)