### PR TITLE
ci: restrict git push patterns to prevent force push

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,8 +42,9 @@ jobs:
             Bash(git fetch *)
             Bash(git add *)
             Bash(git commit *)
-            Bash(git push *)
-            Bash(cd * && git *)
+            Bash(git push)
+            Bash(git push -u origin *)
+            Bash(git push origin *)
 
           # Allow Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Replace broad `Bash(git push *)` with specific patterns: `Bash(git push)`, `Bash(git push -u origin *)`, `Bash(git push origin *)`
- Remove overly broad `Bash(cd * && git *)` compound pattern

This blocks `--force`, `--force-with-lease`, and `--delete` while still allowing normal push operations.

Follow-up to #35 — the review feedback commit didn't make it before merge.

## Test plan
- [ ] Verify Claude can still push commits on a PR
- [ ] Verify `git push --force` is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)