### PR TITLE
feat: unlimited maxTurns for execution tasks

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -355,7 +355,6 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
       const options: Parameters<typeof query>[0]['options'] = {
         abortController,
-        maxTurns: 100,
         permissionMode: 'bypassPermissions',
         // Enable sandbox for standard Claude models (skip for Bedrock/custom models which crash with sandbox option)
         ...getSandboxOption(undefined),
@@ -775,7 +774,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
     // Determine appropriate maxTurns based on task type
     const isTextOnlyTask = task.type === 'chat' || task.type === 'summarize';
-    const defaultMaxTurns = isTextOnlyTask ? 10 : 150;
+    const defaultMaxTurns = isTextOnlyTask ? 10 : undefined;
 
     // Plan/chat/summarize tasks without a working directory run without cwd context
     const hasWorkdir = !!task.workingDirectory;
@@ -793,7 +792,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     // Build options for the query
     const options: Parameters<typeof query>[0]['options'] = {
       abortController,
-      maxTurns: task.maxTurns ?? defaultMaxTurns,
+      ...(task.maxTurns != null || defaultMaxTurns != null ? { maxTurns: task.maxTurns ?? defaultMaxTurns } : {}),
       permissionMode: 'bypassPermissions', // Auto-accept all tool calls
       // Enable sandbox for standard Claude models (skip for Bedrock/custom models which crash with sandbox option)
       ...getSandboxOption(task.model),

--- a/tests/relay-protocol-fields.test.ts
+++ b/tests/relay-protocol-fields.test.ts
@@ -311,12 +311,13 @@ describe('Claude SDK adapter field consumption', () => {
    * This mirrors the logic in claude-sdk-adapter.ts execute().
    */
   function buildQueryParams(task: Task) {
-    // Default maxTurns based on task type
-    const defaultMaxTurns = (task.type === 'chat' || task.type === 'summarize') ? 10 : 150
+    // Default maxTurns based on task type (text-only gets 10, execution gets unlimited)
+    const isTextOnly = task.type === 'chat' || task.type === 'summarize'
+    const defaultMaxTurns = isTextOnly ? 10 : undefined
     const maxTurns = task.maxTurns ?? defaultMaxTurns
 
     const options: Record<string, unknown> = {
-      maxTurns,
+      ...(maxTurns != null ? { maxTurns } : {}),
     }
 
     if (task.outputFormat) {
@@ -399,7 +400,7 @@ describe('Claude SDK adapter field consumption', () => {
     expect(options.maxTurns).toBe(10)
   })
 
-  it('uses maxTurns=150 for execution tasks when not explicitly set', () => {
+  it('uses unlimited maxTurns for execution tasks when not explicitly set', () => {
     const { options } = buildQueryParams({
       id: 'task-1',
       projectId: 'proj-1',
@@ -410,10 +411,10 @@ describe('Claude SDK adapter field consumption', () => {
       createdAt: new Date().toISOString(),
       type: 'execution',
     })
-    expect(options.maxTurns).toBe(150)
+    expect(options.maxTurns).toBeUndefined()
   })
 
-  it('uses maxTurns=150 when type is omitted (backward compatible)', () => {
+  it('uses unlimited maxTurns when type is omitted (backward compatible)', () => {
     const { options } = buildQueryParams({
       id: 'task-1',
       projectId: 'proj-1',
@@ -423,7 +424,7 @@ describe('Claude SDK adapter field consumption', () => {
       workingDirectory: '/tmp',
       createdAt: new Date().toISOString(),
     })
-    expect(options.maxTurns).toBe(150)
+    expect(options.maxTurns).toBeUndefined()
   })
 
   it('explicit maxTurns overrides task-type defaults', () => {


### PR DESCRIPTION
## Summary
- Remove hardcoded `maxTurns` caps for non-text-only queries in the Claude SDK adapter
- Execution tasks no longer pass `maxTurns` to the Claude Agent SDK `query()`, allowing unlimited turns (previously capped at 150)
- Text-only tasks (chat/summarize) retain `maxTurns=10` default
- Single-turn safety check queries retain `maxTurns=1`

## Test plan
- [ ] Verify execution tasks run without turn limit
- [ ] Verify chat/summarize tasks still default to 10 turns
- [ ] Verify explicit `task.maxTurns` override still works
- [ ] Run `npm test` — updated test expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)