### PR TITLE
fix: restrict plan tasks to read-only tools

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -974,9 +974,19 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       }
     }
 
-    // For tasks without a working directory, disable file system and shell tools
-    // but keep web search so the agent can research. MCP tools are also allowed.
-    if (!hasWorkdir) {
+    // Plan tasks are read-only: no file writes, edits, or shell access regardless
+    // of workdir/MCP configuration. Only allow codebase exploration + web search.
+    if (task.type === 'plan') {
+      const planTools = [
+        ...(hasWorkdir ? ['Read', 'Glob', 'Grep'] : []),
+        'WebSearch', 'WebFetch',
+        ...mcpAllowedTools,
+      ];
+      (options as Record<string, unknown>).allowedTools = planTools;
+      console.log(`[claude-sdk] Plan task — read-only tools: [${planTools.join(', ')}]`);
+    } else if (!hasWorkdir) {
+      // For tasks without a working directory, disable file system and shell tools
+      // but keep web search so the agent can research. MCP tools are also allowed.
       const noWorkdirTools = ['WebSearch', 'WebFetch', ...mcpAllowedTools];
       (options as Record<string, unknown>).allowedTools = noWorkdirTools;
       console.log(`[claude-sdk] No workdir — allowed tools: [${noWorkdirTools.join(', ')}]`);


### PR DESCRIPTION
## Summary
- Plan generation tasks now get only read-only tools (`Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch` + MCP) regardless of workdir or MCP configuration
- Prevents the planning agent from accidentally writing files, running shell commands, or modifying the codebase
- Previously, plan tasks with a working directory could access `Write`, `Edit`, `Bash` etc. — this was unintentional

## Test plan
- [ ] Verify plan generation with a repo context still works (can use Read/Glob/Grep to explore)
- [ ] Verify plan generation without a repo context still works (WebSearch/WebFetch only)
- [ ] Confirm no write/edit/bash tools appear in plan task logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)