### PR TITLE
fix: unlimited maxTurns for plan generation tasks

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -636,9 +636,12 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       ? ['Read', 'Grep', 'Glob', 'WebSearch', 'WebFetch']
       : ['WebSearch', 'WebFetch'];
 
+    // Chat/summarize tasks cap at 10 turns; plan tasks run unlimited (like execution)
+    const textOnlyMaxTurns = (isChatTask || task.type === 'summarize') ? 10 : undefined;
+
     const options: Parameters<typeof query>[0]['options'] = {
       abortController,
-      maxTurns: task.maxTurns ?? 10,
+      ...(task.maxTurns != null || textOnlyMaxTurns != null ? { maxTurns: task.maxTurns ?? textOnlyMaxTurns } : {}),
       permissionMode: isChatTask ? 'bypassPermissions' : 'plan',
       ...(isChatTask ? {} : { tools: [] }),
       persistSession: true,


### PR DESCRIPTION
## Summary
- Plan tasks in the text-only query path were capped at `maxTurns: 10`, same as chat/summarize
- This caused plan generation to terminate prematurely for complex projects
- Now only chat/summarize tasks are capped at 10 turns; plan tasks run unlimited (matching execution task behavior)

## Changes
- `runTextOnlyQuery()`: Replace hardcoded `maxTurns: task.maxTurns ?? 10` with conditional logic that only caps chat/summarize tasks at 10

## maxTurns Summary (after this PR)
| Task Type | maxTurns |
|-----------|----------|
| Session init (ping) | 1 |
| Summary | 1 |
| Chat | 10 |
| Plan | **unlimited** |
| Execution | **unlimited** |

## After merging
Merge `dev` → `main` to propagate this fix + the earlier unlimited execution fix to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)