### PR TITLE
fix: add AskUserQuestion to plan task allowed tools

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -976,10 +976,14 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
     // Plan tasks are read-only: no file writes, edits, or shell access regardless
     // of workdir/MCP configuration. Only allow codebase exploration + web search.
+    // AskUserQuestion is included so the model can request clarification from the
+    // user instead of guessing — the approval system routes the question to the
+    // frontend and pauses until the user responds.
     if (task.type === 'plan') {
       const planTools = [
         ...(hasWorkdir ? ['Read', 'Glob', 'Grep'] : []),
         'WebSearch', 'WebFetch',
+        'AskUserQuestion',
         ...mcpAllowedTools,
       ];
       (options as Record<string, unknown>).allowedTools = planTools;


### PR DESCRIPTION
## Summary
- Plan tasks were missing `AskUserQuestion` from their allowed tools list
- When the model needed clarification during planning, it could only output questions as plain text
- The agent would complete its turn with `status=success`, and the frontend marked the session as "completed" even though the user needed to respond
- Now `AskUserQuestion` is included in plan tools — the existing `canUseTool` handler intercepts it, routes through the approval system, and pauses until the user responds

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 433 tests pass
- [ ] Start a plan session with Claude SDK provider
- [ ] Verify the model can ask clarification questions via the approval card UI
- [ ] Verify the session stays in "running" state while waiting for user response
- [ ] Verify the model continues after user responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)