### PR TITLE
fix: address second round review comments on PR #48

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -310,6 +310,7 @@ function probeGatewayReachable(url: string): Promise<boolean> {
       } catch { /* ignore */ }
     });
     ws.on('error', () => { clearTimeout(timeout); resolve(false) });
+    ws.on('close', () => { clearTimeout(timeout); resolve(false) });
   });
 }
 

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -806,7 +806,7 @@ export class WebSocketClient {
       }
 
       // Handle channel.* (dot notation from relay) — normalize to underscore
-      if (raw.type === 'channel.notification' || raw.type === 'channel.response' || raw.type === 'channel.approval_request') {
+      if (typeof raw.type === 'string' && raw.type.startsWith('channel.')) {
         const normalized = {
           ...raw,
           type: raw.type.replace('.', '_'),
@@ -1025,7 +1025,13 @@ export class WebSocketClient {
         payload: { correlationId, approvalId, response },
       });
     } catch (err) {
-      console.warn(`[ws-client] Channel approval ${approvalId} failed:`, err instanceof Error ? err.message : err);
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      console.warn(`[ws-client] Channel approval ${approvalId} failed:`, errorMsg);
+      this.send({
+        type: 'channel_approval_response',
+        timestamp: new Date().toISOString(),
+        payload: { correlationId, approvalId, response: '', error: errorMsg },
+      });
     }
   }
 
@@ -1407,6 +1413,11 @@ export class WebSocketClient {
   private cleanup(): void {
     this.stopHeartbeat();
     this.cancelTokenRefresh();
+
+    if (this.openclawBridge) {
+      this.openclawBridge.stop();
+      this.openclawBridge = null;
+    }
 
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout);

--- a/src/providers/openclaw-adapter.ts
+++ b/src/providers/openclaw-adapter.ts
@@ -200,6 +200,11 @@ export class OpenClawAdapter implements ProviderAdapter {
         clearTimeout(timeout);
         resolve(false);
       });
+
+      ws.on('close', () => {
+        clearTimeout(timeout);
+        resolve(false);
+      });
     });
   }
 
@@ -371,8 +376,7 @@ export class OpenClawAdapter implements ProviderAdapter {
 
           // Filter to our session
           if (p.sessionKey !== `agent:main:${sessionKey}` && p.sessionKey !== sessionKey) {
-            // Also check by runId
-            if (runId && p.runId !== runId) return;
+            return;
           }
 
           const streamType = p.stream as string;
@@ -383,9 +387,25 @@ export class OpenClawAdapter implements ProviderAdapter {
             if (phase === 'start') {
               stream.sessionInit(
                 (p.sessionKey as string) || sessionKey,
-                undefined, // model comes from chat event
+                (eventData?.model as string) || undefined,
               );
             } else if (phase === 'end') {
+              // Extract usage metrics from lifecycle.end if available
+              const usage = eventData?.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+              const cost = (eventData?.total_cost_usd ?? eventData?.cost_usd) as number | undefined;
+              const numTurns = eventData?.num_turns as number | undefined;
+              const durationMs = eventData?.duration_ms as number | undefined;
+              const model = eventData?.model as string | undefined;
+              if (usage || cost !== undefined) {
+                lastMetrics = {
+                  inputTokens: usage?.input_tokens,
+                  outputTokens: usage?.output_tokens,
+                  totalCost: cost,
+                  numTurns,
+                  durationMs,
+                  model,
+                };
+              }
               lifecycleEnded = true;
               tryFinishAfterLifecycle();
             }
@@ -404,6 +424,14 @@ export class OpenClawAdapter implements ProviderAdapter {
             const result = eventData?.result || eventData?.output || '';
             const success = eventData?.success !== false;
             stream.toolResult(toolName, result, success);
+          } else if (streamType === 'file_change') {
+            const filePath = eventData?.path as string || eventData?.file as string;
+            const rawAction = (eventData?.type as string) || (eventData?.action as string) || 'modified';
+            const action = (['created', 'modified', 'deleted'].includes(rawAction) ? rawAction : 'modified') as 'created' | 'modified' | 'deleted';
+            if (filePath) {
+              artifacts.push({ type: 'file', name: filePath, path: filePath, metadata: { action } });
+              stream.fileChange(filePath, action);
+            }
           }
 
           return;
@@ -415,7 +443,7 @@ export class OpenClawAdapter implements ProviderAdapter {
 
           // Filter to our session
           if (p.sessionKey !== `agent:main:${sessionKey}` && p.sessionKey !== sessionKey) {
-            if (runId && p.runId !== runId) return;
+            return;
           }
 
           const state = p.state as string;
@@ -435,6 +463,20 @@ export class OpenClawAdapter implements ProviderAdapter {
                     }
                   }
                 }
+              }
+            }
+            // Extract model/usage from chat.final if not yet captured
+            if (!lastMetrics) {
+              const usage = p.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+              const cost = (p.total_cost_usd ?? p.cost_usd) as number | undefined;
+              const model = (p.model ?? message?.model) as string | undefined;
+              if (usage || cost !== undefined || model) {
+                lastMetrics = {
+                  inputTokens: usage?.input_tokens,
+                  outputTokens: usage?.output_tokens,
+                  totalCost: cost,
+                  model,
+                };
               }
             }
             // If lifecycle already ended, finish immediately

--- a/src/types.ts
+++ b/src/types.ts
@@ -867,6 +867,7 @@ export interface ChannelApprovalResponseMessage extends WSMessage {
     correlationId: string;
     approvalId: string;
     response: string;
+    error?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

Addresses all critical and important issues from the second AI code review on PR #48 (dev→main):

**Critical fixes:**
- **Event filtering logic** — Return immediately when `sessionKey` doesn't match instead of falling through to fragile `runId` check (both agent and chat event handlers)
- **Type safety** — Add `error?: string` to `ChannelApprovalResponseMessage.payload`
- **Error response for approval failures** — Send `channel_approval_response` with error in catch block instead of silently swallowing

**Important fixes:**
- **Bridge cleanup** — Stop OpenClaw bridge on WebSocket disconnect/cleanup
- **Probe close handler** — Add `ws.on('close')` to `probeGatewayReachable` for fast failure
- **Usage metrics** — Extract metrics from `lifecycle.end` and `chat.final` events
- **File change tracking** — Track `file_change` stream events and populate artifacts array
- **Model extraction** — Pass model from `lifecycle.start` to `sessionInit`
- **Generic channel normalization** — Use `startsWith('channel.')` instead of hardcoded list

## Test plan

- [x] `npm run build` passes
- [x] All 419 tests pass (`npm test`)
- [x] OpenClaw gateway adapter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)