### PR TITLE
fix: address PR #48 review issues

### DIFF
--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -66,6 +66,8 @@ export class OpenClawBridge extends EventEmitter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   /** Default recipient for send (e.g., Telegram username, phone). Read from openclaw.json */
   private defaultRecipient: string | null = null;
+  /** Telegram bot token, cached from config at start() */
+  private telegramBotToken: string | null = null;
 
   get isConnected(): boolean {
     return this._connected && this.ws !== null && this.ws.readyState === WebSocket.OPEN;
@@ -81,6 +83,7 @@ export class OpenClawBridge extends EventEmitter {
 
     this.gatewayConfig = config;
     this.defaultRecipient = config.defaultRecipient || null;
+    this.telegramBotToken = this.readTelegramBotToken();
     this._started = true;
     await this.connect();
     return this._connected;
@@ -381,7 +384,7 @@ export class OpenClawBridge extends EventEmitter {
 
     const options = opts.options ?? ['Yes', 'No'];
 
-    const botToken = this.readTelegramBotToken();
+    const botToken = this.telegramBotToken;
     if (botToken) {
       return this.requestApprovalViaTelegram(botToken, to, opts.question, options);
     }

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -297,8 +297,9 @@ async function detectCodex(): Promise<ProviderInfo | null> {
  */
 function probeGatewayReachable(url: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const timeout = setTimeout(() => { ws.close(); resolve(false) }, 5000);
-    const ws = new WebSocket(url);
+    let ws: WebSocket | undefined;
+    const timeout = setTimeout(() => { ws?.close(); resolve(false) }, 5000);
+    ws = new WebSocket(url);
     ws.on('message', (data) => {
       try {
         const frame = JSON.parse(String(data));

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -809,7 +809,7 @@ export class WebSocketClient {
       if (typeof raw.type === 'string' && raw.type.startsWith('channel.')) {
         const normalized = {
           ...raw,
-          type: raw.type.replace('.', '_'),
+          type: raw.type.replaceAll('.', '_'),
         } as unknown as IncomingMessage;
         this.routeMessage(normalized);
         return;
@@ -911,29 +911,32 @@ export class WebSocketClient {
     if (this.openclawBridge) return;
 
     const bridge = new OpenClawBridge();
+    this.openclawBridge = bridge; // Assign immediately to prevent double-start on rapid reconnect
     bridge.start().then((connected) => {
-      if (connected) {
-        this.openclawBridge = bridge;
-        console.log('[ws-client] OpenClaw bridge started for channel relay');
-
-        // Forward inbound messages from OpenClaw to the server
-        bridge.on('inbound', (payload: Record<string, unknown>) => {
-          this.send({
-            type: 'channel_inbound',
-            timestamp: new Date().toISOString(),
-            payload: {
-              sourceMessageId: (payload.messageId as string) ?? String(Date.now()),
-              text: (payload.text as string) ?? '',
-              senderId: (payload.senderId as string) ?? 'unknown',
-              senderName: (payload.senderName as string) ?? 'unknown',
-              channelId: (payload.channelId as string) ?? '',
-              threadId: payload.threadId as string | undefined,
-              metadata: payload.metadata as Record<string, unknown> | undefined,
-            },
-          });
-        });
+      if (!connected) {
+        this.openclawBridge = null;
+        return;
       }
+      console.log('[ws-client] OpenClaw bridge started for channel relay');
+
+      // Forward inbound messages from OpenClaw to the server
+      bridge.on('inbound', (payload: Record<string, unknown>) => {
+        this.send({
+          type: 'channel_inbound',
+          timestamp: new Date().toISOString(),
+          payload: {
+            sourceMessageId: (payload.messageId as string) ?? String(Date.now()),
+            text: (payload.text as string) ?? '',
+            senderId: (payload.senderId as string) ?? 'unknown',
+            senderName: (payload.senderName as string) ?? 'unknown',
+            channelId: (payload.channelId as string) ?? '',
+            threadId: payload.threadId as string | undefined,
+            metadata: payload.metadata as Record<string, unknown> | undefined,
+          },
+        });
+      });
     }).catch((err) => {
+      this.openclawBridge = null;
       console.warn('[ws-client] Failed to start OpenClaw bridge:', err);
     });
   }

--- a/src/providers/openclaw-adapter.ts
+++ b/src/providers/openclaw-adapter.ts
@@ -63,6 +63,7 @@ export class OpenClawAdapter implements ProviderAdapter {
   private maxTasks = 10;
   private lastError?: string;
   private gatewayConfig: GatewayConfig | null = null;
+  private lastAvailableCheck: { available: boolean; at: number } | null = null;
 
   async isAvailable(): Promise<boolean> {
     const config = this.readGatewayConfig();
@@ -73,8 +74,10 @@ export class OpenClawAdapter implements ProviderAdapter {
     // Probe the gateway with a quick connect
     try {
       const ok = await this.probeGateway(config);
+      this.lastAvailableCheck = { available: ok, at: Date.now() };
       return ok;
     } catch {
+      this.lastAvailableCheck = { available: false, at: Date.now() };
       return false;
     }
   }
@@ -137,7 +140,14 @@ export class OpenClawAdapter implements ProviderAdapter {
   }
 
   async getStatus(): Promise<ProviderStatus> {
-    const available = await this.isAvailable();
+    // Use cached availability if checked within the last 30 seconds to avoid
+    // opening a new WebSocket probe on every status poll
+    let available: boolean;
+    if (this.lastAvailableCheck && Date.now() - this.lastAvailableCheck.at < 30_000) {
+      available = this.lastAvailableCheck.available;
+    } else {
+      available = await this.isAvailable();
+    }
     return {
       available,
       version: null,
@@ -176,20 +186,24 @@ export class OpenClawAdapter implements ProviderAdapter {
 
   private probeGateway(config: GatewayConfig): Promise<boolean> {
     return new Promise((resolve) => {
+      let resolved = false;
+      const done = (val: boolean) => { if (!resolved) { resolved = true; resolve(val); } };
+
+      let ws: WebSocket | undefined;
       const timeout = setTimeout(() => {
-        ws.close();
-        resolve(false);
+        ws?.close();
+        done(false);
       }, 5000);
 
-      const ws = new WebSocket(config.url);
+      ws = new WebSocket(config.url);
 
       ws.on('message', (data) => {
         try {
           const frame = JSON.parse(String(data)) as GatewayFrame;
           if (frame.type === 'event' && frame.event === 'connect.challenge') {
             clearTimeout(timeout);
-            ws.close();
-            resolve(true);
+            ws!.close();
+            done(true);
           }
         } catch {
           // ignore
@@ -198,12 +212,12 @@ export class OpenClawAdapter implements ProviderAdapter {
 
       ws.on('error', () => {
         clearTimeout(timeout);
-        resolve(false);
+        done(false);
       });
 
       ws.on('close', () => {
         clearTimeout(timeout);
-        resolve(false);
+        done(false);
       });
     });
   }
@@ -212,12 +226,13 @@ export class OpenClawAdapter implements ProviderAdapter {
 
   private connectToGateway(config: GatewayConfig): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
+      let ws: WebSocket | undefined;
       const timeout = setTimeout(() => {
-        ws.close();
+        ws?.close();
         reject(new Error('Gateway connection timeout'));
       }, CONNECT_TIMEOUT_MS);
 
-      const ws = new WebSocket(config.url);
+      ws = new WebSocket(config.url);
 
       ws.on('message', (data) => {
         try {
@@ -299,6 +314,7 @@ export class OpenClawAdapter implements ProviderAdapter {
       const finish = (error?: string) => {
         if (finished) return;
         finished = true;
+        signal.removeEventListener('abort', abortHandler);
         if (taskTimeout) clearTimeout(taskTimeout);
         if (gracePeriodTimeout) clearTimeout(gracePeriodTimeout);
         ws.close();
@@ -522,11 +538,7 @@ export class OpenClawAdapter implements ProviderAdapter {
         },
       }));
 
-      // Ensure signal listener and timeout are cleaned up when ws closes
-      ws.on('close', () => {
-        signal.removeEventListener('abort', abortHandler);
-        if (taskTimeout) clearTimeout(taskTimeout);
-      });
+      // Note: signal listener and timeout cleanup is handled in finish()
     });
   }
 }

--- a/tests/openclaw-gateway-adapter.test.ts
+++ b/tests/openclaw-gateway-adapter.test.ts
@@ -52,10 +52,20 @@ class MockGateway {
   port: number
   connections: import('ws').WebSocket[] = []
   onChatSend?: (params: Record<string, unknown>, ws: import('ws').WebSocket) => void
+  private _ready: Promise<void>
 
   constructor(port: number) {
     this.port = port
     this.wss = new WebSocketServer({ port })
+    this._ready = new Promise((resolve) => {
+      this.wss.on('listening', () => {
+        const addr = this.wss.address()
+        if (typeof addr === 'object' && addr) {
+          this.port = addr.port
+        }
+        resolve()
+      })
+    })
 
     this.wss.on('connection', (ws) => {
       this.connections.push(ws)
@@ -158,6 +168,10 @@ class MockGateway {
     })
   }
 
+  async waitReady(): Promise<void> {
+    await this._ready
+  }
+
   async close(): Promise<void> {
     for (const ws of this.connections) {
       ws.close()
@@ -178,12 +192,10 @@ describe('OpenClaw Gateway Adapter', () => {
   let port: number
 
   beforeEach(async () => {
-    // Use a random port to avoid conflicts
-    port = 19000 + Math.floor(Math.random() * 1000)
-    gateway = new MockGateway(port)
-
-    // Wait for server to be ready
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    // Use port 0 for OS-assigned port to avoid conflicts in parallel test runs
+    gateway = new MockGateway(0)
+    await gateway.waitReady()
+    port = gateway.port
 
     adapter = new OpenClawAdapter()
     // Override config discovery to use our test port


### PR DESCRIPTION
## Summary
Addresses all review comments from PR #48's AI code reviews plus additional issues found by a manual code review pass.

### Fixes from AI review comments (rounds 1-3):
- **TDZ bugs** (Critical): `probeGateway`, `connectToGateway`, and `probeGatewayReachable` all referenced `ws` in timeout callbacks before it was declared — would crash with ReferenceError if the WebSocket constructor throws
- **`.replace('.', '_')`** only replaced the first dot occurrence in channel message type normalization — switched to `.replaceAll()`

### Additional issues found via code review:
- **Race condition in `startOpenClawBridge`** (Critical): Bridge was assigned asynchronously after `start()` resolved, so rapid relay reconnects could double-start bridges, leaking connections and event listeners. Fixed by assigning synchronously before `start()`.
- **`probeGateway` double-resolve**: `close` handler called `resolve(false)` after `resolve(true)` was already called. Added a resolved guard.
- **`abortHandler` cleanup split across two `close` handlers**: Consolidated into `finish()` and removed redundant second handler.
- **`getStatus()` gateway probing**: Created a new WebSocket probe on every status poll. Added 30s cache.
- **Config file read twice per approval**: `readTelegramBotToken()` re-read `~/.openclaw/openclaw.json` on every call. Cached at `start()`.
- **Test port collisions**: Random port in 19000-19999 range replaced with OS-assigned port 0.

## Test plan
- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 419 tests pass
- [x] OpenClaw gateway adapter tests pass with OS-assigned ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)