### PR TITLE
fix: address all remaining PR #48 review issues

### DIFF
--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -111,6 +111,7 @@ export class OpenClawBridge extends EventEmitter {
     }
 
     if (this.ws) {
+      this.ws.removeAllListeners();
       this.ws.close();
       this.ws = null;
     }
@@ -231,6 +232,7 @@ export class OpenClawBridge extends EventEmitter {
       ws.on('error', (err) => {
         console.error('[openclaw-bridge] WebSocket error:', err.message);
         clearTimeout(timeout);
+        ws.close();
         resolve();
       });
     });
@@ -309,6 +311,9 @@ export class OpenClawBridge extends EventEmitter {
       // using the fallback path (no bot token) may match responses to the wrong request.
       // The Telegram polling path (requestApprovalViaTelegram) avoids this issue.
       if (this.pendingApprovals.size > 0 && text.trim()) {
+        if (this.pendingApprovals.size > 1) {
+          console.warn(`[openclaw-bridge] ${this.pendingApprovals.size} concurrent approvals pending — FIFO matching may route response to wrong request`);
+        }
         const [approvalId] = this.pendingApprovals.keys();
         this.resolveApproval(approvalId, text.trim());
         return;

--- a/src/providers/openclaw-adapter.ts
+++ b/src/providers/openclaw-adapter.ts
@@ -253,6 +253,7 @@ export class OpenClawAdapter implements ProviderAdapter {
    * Get preserved session context for a task (used by task executor for resume routing).
    */
   getTaskContext(taskId: string): { sessionId: string; workingDirectory: string } | null {
+    this.cleanupExpiredSessions();
     const session = this.preservedSessions.get(taskId);
     if (!session || Date.now() - session.createdAt > SESSION_TTL_MS) {
       this.preservedSessions.delete(taskId);
@@ -318,6 +319,7 @@ export class OpenClawAdapter implements ProviderAdapter {
           const frame = JSON.parse(String(data)) as GatewayFrame;
           if (frame.type === 'event' && frame.event === 'connect.challenge') {
             clearTimeout(timeout);
+            ws!.removeAllListeners();
             ws!.close();
             done(true);
           }
@@ -328,6 +330,7 @@ export class OpenClawAdapter implements ProviderAdapter {
 
       ws.on('error', () => {
         clearTimeout(timeout);
+        ws?.removeAllListeners();
         done(false);
       });
 
@@ -439,6 +442,7 @@ export class OpenClawAdapter implements ProviderAdapter {
         signal.removeEventListener('abort', abortHandler);
         if (taskTimeout) clearTimeout(taskTimeout);
         if (gracePeriodTimeout) clearTimeout(gracePeriodTimeout);
+        ws.removeAllListeners();
         ws.close();
         resolve({
           output: outputText,
@@ -694,6 +698,7 @@ export class OpenClawAdapter implements ProviderAdapter {
         finished = true;
         signal.removeEventListener('abort', abortHandler);
         if (gracePeriodTimeout) clearTimeout(gracePeriodTimeout);
+        ws.removeAllListeners();
         ws.close();
         resolve({ output: outputText, error });
       };


### PR DESCRIPTION
## Summary
Fixes all Critical + Important issues from the latest AI review round on PR #48:

**Critical:**
- WebSocket event listener leaks in `runViaGateway()` and `sendChatMessage()` — added `ws.removeAllListeners()` before `ws.close()` in both `finish()` functions
- Missing `ws.close()` in `openclaw-bridge.ts` error handler — socket remained open on connection error

**Important:**
- Expired session accumulation — added `cleanupExpiredSessions()` in `getTaskContext()` so sessions are cleaned on query, not only on new task execution
- `probeGateway()` and `stop()` listener cleanup — added `removeAllListeners()` before close
- FIFO approval matching — added runtime warning when multiple concurrent approvals are pending in fallback mode

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 419 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)