### PR TITLE
fix: prevent false sbatch detection from blocking task results

### DIFF
--- a/src/lib/slurm-job-monitor.ts
+++ b/src/lib/slurm-job-monitor.ts
@@ -66,7 +66,8 @@ export class SlurmJobMonitor {
     try {
       await execFileAsync('sacct', ['--version'], { timeout: 5_000 });
       this.sacctAvailable = true;
-    } catch {
+    } catch (err) {
+      console.log('[slurm-monitor] sacct not available:', err instanceof Error ? err.message : err);
       this.sacctAvailable = false;
     }
     return this.sacctAvailable;
@@ -194,6 +195,9 @@ export class SlurmJobMonitor {
 
       // sacct can return multiple lines (job + job.batch steps)
       // Take the first line (main job)
+      // Reset failure counter on successful poll
+      job.pollFailures = 0;
+
       const firstLine = stdout.trim().split('\n')[0];
       if (firstLine) {
         const parts = firstLine.split('|');

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -45,6 +45,9 @@ import { buildHpcContext, type HpcContext } from '../lib/hpc-context.js';
 import type { SlurmJobMonitor } from '../lib/slurm-job-monitor.js';
 import { config } from '../lib/config.js';
 
+/** Shell execution tools whose output may contain real sbatch submissions */
+const SHELL_TOOLS = new Set(['Bash', 'bash', 'shell', 'execute_command', 'terminal']);
+
 /**
  * Determine whether to enable sandbox mode for Claude Code.
  *
@@ -1137,7 +1140,6 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
             // Detect sbatch submissions for job tracking.
             // Layer 1: Only scan results from shell execution tools to avoid false
             // positives when the AI reads docs containing example sbatch output.
-            const SHELL_TOOLS = new Set(['Bash', 'bash', 'shell', 'execute_command', 'terminal']);
             const resolvedToolName = block.tool_use_id ? toolUseNames.get(block.tool_use_id) : undefined;
             if (this.jobMonitor && typeof resultContent === 'string'
                 && resolvedToolName && SHELL_TOOLS.has(resolvedToolName)) {
@@ -1147,7 +1149,10 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
                 // Try to extract output path from sbatch script (common pattern: --output=...)
                 const outputMatch = resultContent.match(/--output[= ](\S+)/);
                 const outputPath = outputMatch?.[1]?.replace('%j', jobId);
-                await this.jobMonitor.trackJob(jobId, task.id, task.planNodeId, outputPath);
+                // Fire-and-forget: don't block message processing while sacct is probed
+                this.jobMonitor.trackJob(jobId, task.id, task.planNodeId, outputPath).catch((err) => {
+                  console.error(`[claude-sdk] Failed to track sbatch job ${jobId}:`, err);
+                });
                 console.log(`[claude-sdk] Detected sbatch submission: job ${jobId} (tool: ${resolvedToolName})`);
               }
             }


### PR DESCRIPTION
## Summary

Plan generation (and any task that reads HPC documentation) hangs indefinitely because the sbatch job detection regex falsely matches example text in docs.

**Root cause chain:**
1. AI reads `docs/design/HPC_WORKFLOW.md` via `Read` tool (expected behavior for HPC-related planning)
2. `claude-sdk-adapter.ts:1136` regex scans ALL tool results for `"Submitted batch job (\d+)"` — matches example text at line 124
3. `SlurmJobMonitor.trackJob()` registers fake job `12345`
4. On machines without `sacct`, `pollJob()` silently fails (`catch { return }`) — job stays tracked forever
5. `task-executor.ts:1190` finds pending jobs → blocks `sendTaskResult()` → task hangs

**Reproduced 3 times** in production with concrete agent-runner log evidence.

## Fix: Three-Layer Defense

| Layer | File | What |
|-------|------|------|
| **1. Tool name gating** | `claude-sdk-adapter.ts` | Build `tool_use_id → tool_name` map; only scan `Bash`/shell tool results for sbatch patterns |
| **2. Validate before tracking** | `slurm-job-monitor.ts` | `trackJob()` checks if `sacct` is available; skips tracking on non-Slurm machines |
| **3. Timeout stale jobs** | `slurm-job-monitor.ts` | Untrack jobs after 3 consecutive `sacct` failures — safety net against any future edge case |

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 419 tests pass
- [ ] Deploy: plan generation for HPC-related tasks no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)