### PR TITLE
feat: add file_content_request and file_upload handlers (#62)

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -370,6 +370,16 @@ export async function startCommand(options: StartOptions = {}): Promise<void> {
   // eslint-disable-next-line prefer-const -- reassigned on line 530 after wsClient creation
   let taskExecutor: TaskExecutor;
 
+  // Track in-progress file upload sessions for chunked transfers
+  let uploadSessions: Map<string, {
+    destinationPath: string;
+    fileName: string;
+    fullPath: string;
+    totalChunks: number;
+    chunks: Map<number, { encoding: string; content: string }>;
+    tmpPath: string;
+  }> | undefined;
+
   const wsClient = new WebSocketClient({
     runnerId,
     machineId,
@@ -446,6 +456,167 @@ export async function startCommand(options: StartOptions = {}): Promise<void> {
       } catch (error) {
         log('warn', `Failed to list files in ${path}: ${error instanceof Error ? error.message : String(error)}`, logLevel);
         wsClient.sendFileListResponse(correlationId, []);
+      }
+    },
+    onFileContent: (path: string, correlationId: string) => {
+      log('debug', `File content request for path: ${path}`, logLevel);
+      try {
+        if (!existsSync(path)) {
+          wsClient.sendFileContentResponse(correlationId, path, undefined, undefined, undefined, undefined, 'File not found');
+          return;
+        }
+
+        const stat = statSync(path);
+        if (stat.isDirectory()) {
+          wsClient.sendFileContentResponse(correlationId, path, undefined, undefined, undefined, undefined, 'Path is a directory');
+          return;
+        }
+
+        const ext = path.split('.').pop()?.toLowerCase() ?? '';
+        const mimeMap: Record<string, string> = {
+          png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+          webp: 'image/webp', svg: 'image/svg+xml', pdf: 'application/pdf',
+          json: 'application/json', xml: 'application/xml',
+          html: 'text/html', htm: 'text/html', css: 'text/css',
+          js: 'text/javascript', ts: 'text/javascript', tsx: 'text/javascript', jsx: 'text/javascript',
+          md: 'text/markdown', txt: 'text/plain', csv: 'text/csv',
+          py: 'text/x-python', rb: 'text/x-ruby', go: 'text/x-go',
+          rs: 'text/x-rust', java: 'text/x-java', c: 'text/x-c', cpp: 'text/x-c++',
+          sh: 'text/x-shellscript', yaml: 'text/yaml', yml: 'text/yaml',
+          toml: 'text/toml',
+        };
+        const mimeType = mimeMap[ext] ?? 'application/octet-stream';
+
+        const textTypes = ['text/', 'application/json', 'application/xml', 'image/svg+xml'];
+        const isText = textTypes.some(t => mimeType.startsWith(t));
+
+        const fileBuffer = readFileSync(path);
+        const CHUNK_SIZE = 1024 * 1024; // 1MB chunks
+
+        if (fileBuffer.length > CHUNK_SIZE) {
+          const encoding = isText ? 'utf-8' as const : 'base64' as const;
+          const fullContent = isText ? fileBuffer.toString('utf-8') : fileBuffer.toString('base64');
+          const totalChunks = Math.ceil(fullContent.length / CHUNK_SIZE);
+
+          for (let i = 0; i < totalChunks; i++) {
+            const chunk = fullContent.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+            wsClient.sendFileContentResponse(
+              correlationId, path, chunk, encoding, mimeType, fileBuffer.length,
+              undefined, true, i, totalChunks,
+            );
+          }
+          log('debug', `Sent file content for ${path} in ${totalChunks} chunks (${fileBuffer.length} bytes)`, logLevel);
+        } else {
+          const encoding = isText ? 'utf-8' as const : 'base64' as const;
+          const content = isText ? fileBuffer.toString('utf-8') : fileBuffer.toString('base64');
+          wsClient.sendFileContentResponse(
+            correlationId, path, content, encoding, mimeType, fileBuffer.length,
+          );
+          log('debug', `Sent file content for ${path} (${fileBuffer.length} bytes)`, logLevel);
+        }
+      } catch (error) {
+        log('warn', `Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`, logLevel);
+        wsClient.sendFileContentResponse(correlationId, path, undefined, undefined, undefined, undefined, `Failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+    onFileUpload: (destinationPath: string, fileName: string, size: number, totalChunks: number, overwrite: boolean, correlationId: string) => {
+      log('debug', `File upload request: ${fileName} -> ${destinationPath} (${size} bytes, ${totalChunks} chunks, overwrite=${overwrite})`, logLevel);
+
+      // Security: reject path traversal
+      if (fileName.includes('..') || destinationPath.includes('..')) {
+        wsClient.sendFileUploadResponse(correlationId, false, undefined, 'Path traversal not allowed');
+        return;
+      }
+
+      // Security: reject sensitive paths
+      const sensitivePatterns = ['/etc/', '/.ssh/', '/usr/', '/bin/', '/sbin/'];
+      const resolvedDest = destinationPath === '~' ? homedir() : destinationPath;
+      if (sensitivePatterns.some(p => resolvedDest.includes(p))) {
+        wsClient.sendFileUploadResponse(correlationId, false, undefined, 'Upload to sensitive path not allowed');
+        return;
+      }
+
+      // Size limit: 50MB
+      if (size > 50 * 1024 * 1024) {
+        wsClient.sendFileUploadResponse(correlationId, false, undefined, 'File too large (max 50MB)');
+        return;
+      }
+
+      const fullPath = join(resolvedDest, fileName);
+
+      // Check for conflicts
+      if (existsSync(fullPath) && !overwrite) {
+        wsClient.sendFileUploadResponse(correlationId, false, fullPath, 'File already exists');
+        return;
+      }
+
+      // Ensure destination directory exists
+      try {
+        mkdirSync(resolvedDest, { recursive: true });
+      } catch (err) {
+        wsClient.sendFileUploadResponse(correlationId, false, undefined, `Cannot create directory: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+      }
+
+      // For single-chunk uploads, wait for the chunk to arrive
+      // For multi-chunk, store metadata for chunk assembly
+      if (!uploadSessions) {
+        uploadSessions = new Map();
+      }
+      uploadSessions.set(correlationId, {
+        destinationPath: resolvedDest,
+        fileName,
+        fullPath,
+        totalChunks,
+        chunks: new Map(),
+        tmpPath: `${fullPath}.tmp.${correlationId.slice(0, 8)}`,
+      });
+      log('debug', `Upload session created for ${correlationId}: ${fullPath}`, logLevel);
+    },
+    onFileUploadChunk: (correlationId: string, chunkIndex: number, encoding: 'utf-8' | 'base64', content: string) => {
+      if (!uploadSessions?.has(correlationId)) {
+        log('warn', `Received chunk for unknown upload session: ${correlationId}`, logLevel);
+        wsClient.sendFileUploadResponse(correlationId, false, undefined, 'Unknown upload session');
+        return;
+      }
+
+      const session = uploadSessions.get(correlationId)!;
+      session.chunks.set(chunkIndex, { encoding, content });
+      log('debug', `Received chunk ${chunkIndex + 1}/${session.totalChunks} for ${session.fileName}`, logLevel);
+
+      // Check if all chunks received
+      if (session.chunks.size >= session.totalChunks) {
+        try {
+          // Reassemble chunks in order
+          const orderedChunks: Buffer[] = [];
+          for (let i = 0; i < session.totalChunks; i++) {
+            const chunk = session.chunks.get(i);
+            if (!chunk) {
+              throw new Error(`Missing chunk ${i}`);
+            }
+            orderedChunks.push(
+              chunk.encoding === 'base64'
+                ? Buffer.from(chunk.content, 'base64')
+                : Buffer.from(chunk.content, 'utf-8')
+            );
+          }
+
+          const fullBuffer = Buffer.concat(orderedChunks);
+
+          // Atomic write: write to temp file then rename
+          writeFileSync(session.tmpPath, fullBuffer);
+          renameSync(session.tmpPath, session.fullPath);
+
+          wsClient.sendFileUploadResponse(correlationId, true, session.fullPath);
+          log('debug', `Upload complete: ${session.fullPath} (${fullBuffer.length} bytes)`, logLevel);
+        } catch (error) {
+          // Clean up temp file on error
+          try { unlinkSync(session.tmpPath); } catch { /* ignore */ }
+          wsClient.sendFileUploadResponse(correlationId, false, undefined, `Write failed: ${error instanceof Error ? error.message : String(error)}`);
+          log('warn', `Upload write failed for ${session.fullPath}: ${error instanceof Error ? error.message : String(error)}`, logLevel);
+        } finally {
+          uploadSessions.delete(correlationId);
+        }
       }
     },
     onDirectoryList: (path: string, correlationId: string) => {

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -31,6 +31,11 @@ import type {
   ErrorMessage,
   FileListRequestMessage,
   FileListResponseMessage,
+  FileContentRequestMessage,
+  FileContentResponseMessage,
+  FileUploadRequestMessage,
+  FileUploadChunkMessage,
+  FileUploadResponseMessage,
   DirectoryListRequestMessage,
   DirectoryListResponseMessage,
   CreateDirectoryRequestMessage,
@@ -84,6 +89,9 @@ export interface WebSocketClientOptions {
   onTaskSafetyDecision?: (taskId: string, decision: 'proceed' | 'init-git' | 'sandbox' | 'cancel') => void;
   onTaskCleanup?: (taskId: string, branchName?: string) => void;
   onFileList?: (path: string, correlationId: string) => void;
+  onFileContent?: (path: string, correlationId: string) => void;
+  onFileUpload?: (destinationPath: string, fileName: string, size: number, totalChunks: number, overwrite: boolean, correlationId: string) => void;
+  onFileUploadChunk?: (correlationId: string, chunkIndex: number, encoding: 'utf-8' | 'base64', content: string) => void;
   onDirectoryList?: (path: string, correlationId: string) => void;
   onCreateDirectory?: (parentPath: string, name: string, correlationId: string) => void;
   onRepoSetup?: (payload: RepoSetupRequestMessage['payload']) => void;
@@ -114,6 +122,9 @@ type IncomingMessage =
   | TaskSafetyDecisionMessage
   | ConfigUpdateMessage
   | FileListRequestMessage
+  | FileContentRequestMessage
+  | FileUploadRequestMessage
+  | FileUploadChunkMessage
   | DirectoryListRequestMessage
   | CreateDirectoryRequestMessage
   | RepoSetupRequestMessage
@@ -156,6 +167,9 @@ export class WebSocketClient {
   private onTaskSafetyDecision?: (taskId: string, decision: 'proceed' | 'init-git' | 'sandbox' | 'cancel') => void;
   private onTaskCleanup?: (taskId: string, branchName?: string) => void;
   private onFileList?: (path: string, correlationId: string) => void;
+  private onFileContent?: (path: string, correlationId: string) => void;
+  private onFileUpload?: (destinationPath: string, fileName: string, size: number, totalChunks: number, overwrite: boolean, correlationId: string) => void;
+  private onFileUploadChunk?: (correlationId: string, chunkIndex: number, encoding: 'utf-8' | 'base64', content: string) => void;
   private onDirectoryList?: (path: string, correlationId: string) => void;
   private onCreateDirectory?: (parentPath: string, name: string, correlationId: string) => void;
   private onRepoSetup?: (payload: RepoSetupRequestMessage['payload']) => void;
@@ -180,6 +194,9 @@ export class WebSocketClient {
     this.onTaskSafetyDecision = options.onTaskSafetyDecision;
     this.onTaskCleanup = options.onTaskCleanup;
     this.onFileList = options.onFileList;
+    this.onFileContent = options.onFileContent;
+    this.onFileUpload = options.onFileUpload;
+    this.onFileUploadChunk = options.onFileUploadChunk;
     this.onDirectoryList = options.onDirectoryList;
     this.onCreateDirectory = options.onCreateDirectory;
     this.onRepoSetup = options.onRepoSetup;
@@ -854,6 +871,15 @@ export class WebSocketClient {
       case 'file_list_request':
         this.handleFileListRequest(message as FileListRequestMessage);
         break;
+      case 'file_content_request':
+        this.handleFileContentRequest(message as FileContentRequestMessage);
+        break;
+      case 'file_upload_request':
+        this.handleFileUploadRequest(message as FileUploadRequestMessage);
+        break;
+      case 'file_upload_chunk':
+        this.handleFileUploadChunk(message as FileUploadChunkMessage);
+        break;
       case 'directory_list_request':
         this.handleDirectoryListRequest(message as DirectoryListRequestMessage);
         break;
@@ -1161,6 +1187,56 @@ export class WebSocketClient {
       type: 'file_list_response',
       timestamp: new Date().toISOString(),
       payload: { correlationId, files },
+    };
+    this.send(msg);
+  }
+
+  private handleFileContentRequest(message: FileContentRequestMessage): void {
+    const { path, correlationId } = message.payload;
+    this.onFileContent?.(path, correlationId);
+  }
+
+  /**
+   * Send file content response
+   */
+  sendFileContentResponse(
+    correlationId: string,
+    path: string,
+    content?: string,
+    encoding?: 'utf-8' | 'base64',
+    mimeType?: string,
+    size?: number,
+    error?: string,
+    chunked?: boolean,
+    chunkIndex?: number,
+    totalChunks?: number,
+  ): void {
+    const msg: FileContentResponseMessage = {
+      type: 'file_content_response',
+      timestamp: new Date().toISOString(),
+      payload: { correlationId, path, content, encoding, mimeType, size, error, chunked, chunkIndex, totalChunks },
+    };
+    this.send(msg);
+  }
+
+  private handleFileUploadRequest(message: FileUploadRequestMessage): void {
+    const { destinationPath, fileName, size, totalChunks, overwrite, correlationId } = message.payload;
+    this.onFileUpload?.(destinationPath, fileName, size, totalChunks, overwrite, correlationId);
+  }
+
+  private handleFileUploadChunk(message: FileUploadChunkMessage): void {
+    const { correlationId, chunkIndex, encoding, content } = message.payload;
+    this.onFileUploadChunk?.(correlationId, chunkIndex, encoding, content);
+  }
+
+  /**
+   * Send file upload response
+   */
+  sendFileUploadResponse(correlationId: string, success: boolean, path?: string, error?: string): void {
+    const msg: FileUploadResponseMessage = {
+      type: 'file_upload_response',
+      timestamp: new Date().toISOString(),
+      payload: { correlationId, success, path, error },
     };
     this.send(msg);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,8 @@ export type WSMessageType =
   | 'task_safety_response'
   | 'resource_update'
   | 'file_list_response'
+  | 'file_content_response'
+  | 'file_upload_response'
   | 'directory_list_response'
   | 'create_directory_response'
   | 'slash_commands_response'
@@ -312,6 +314,9 @@ export type WSMessageType =
   | 'task_safety_decision'
   | 'config_update'
   | 'file_list_request'
+  | 'file_content_request'
+  | 'file_upload_request'
+  | 'file_upload_chunk'
   | 'directory_list_request'
   | 'create_directory_request'
   | 'repo_setup_request'
@@ -605,6 +610,62 @@ export interface DirectoryListResponseMessage extends WSMessage {
     }>;
     error?: string;
     homeDirectory?: string;
+  };
+}
+
+export interface FileContentRequestMessage extends WSMessage {
+  type: 'file_content_request';
+  payload: {
+    path: string;
+    correlationId: string;
+  };
+}
+
+export interface FileContentResponseMessage extends WSMessage {
+  type: 'file_content_response';
+  payload: {
+    correlationId: string;
+    path: string;
+    content?: string;
+    encoding?: 'utf-8' | 'base64';
+    mimeType?: string;
+    size?: number;
+    chunked?: boolean;
+    chunkIndex?: number;
+    totalChunks?: number;
+    error?: string;
+  };
+}
+
+export interface FileUploadRequestMessage extends WSMessage {
+  type: 'file_upload_request';
+  payload: {
+    correlationId: string;
+    destinationPath: string;
+    fileName: string;
+    size: number;
+    totalChunks: number;
+    overwrite: boolean;
+  };
+}
+
+export interface FileUploadChunkMessage extends WSMessage {
+  type: 'file_upload_chunk';
+  payload: {
+    correlationId: string;
+    chunkIndex: number;
+    encoding: 'utf-8' | 'base64';
+    content: string;
+  };
+}
+
+export interface FileUploadResponseMessage extends WSMessage {
+  type: 'file_upload_response';
+  payload: {
+    correlationId: string;
+    success: boolean;
+    path?: string;
+    error?: string;
   };
 }
 


### PR DESCRIPTION
The agent runner was missing handlers for file_content_request, file_upload_request, and file_upload_chunk messages from the relay. This caused file preview and file upload in the web UI to fail with 500 errors (30s timeout) even though the machine was connected.

File content handler:
- Reads files from disk and sends content back via relay
- Auto-detects MIME types from file extension
- Uses base64 encoding for binary files, utf-8 for text
- Supports chunked transfer for files >1MB

File upload handler:
- Receives chunked file uploads via relay
- Security: rejects path traversal, sensitive paths, >50MB files
- Atomic writes via temp file + rename
- Conflict detection when file exists and overwrite=false