### PR TITLE
feat: agent-driven merge conflict resolution with pre-merge rebase — enabling parallel task execution

### DIFF
--- a/src/lib/__tests__/merge-conflict-resolution.test.ts
+++ b/src/lib/__tests__/merge-conflict-resolution.test.ts
@@ -15,6 +15,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // 1. Prompt generation functions (mirrors task-executor.ts lines 41-100)
 // ============================================================================
 
+/** Mirror of sanitizeGitRef from task-executor.ts */
+function sanitizeGitRef(ref: string): string {
+  return ref.replace(/[^a-zA-Z0-9/_.\-]/g, '');
+}
+
 /**
  * Mirror of buildConflictResolutionPrompt from task-executor.ts.
  * Tested separately to verify prompt content without needing the full executor.
@@ -25,6 +30,7 @@ function buildConflictResolutionPrompt(
   attempt: number,
   maxAttempts: number,
 ): string {
+  const safeBranch = sanitizeGitRef(projectBranch);
   const fileList = conflictFiles.map(f => `- ${f}`).join('\n');
   return `MERGE CONFLICT DETECTED (attempt ${attempt}/${maxAttempts})
 
@@ -34,11 +40,11 @@ parallel tasks have modified overlapping files since you branched.
 Conflicting files:
 ${fileList}
 
-The project branch is: ${projectBranch}
+The project branch is: ${safeBranch}
 
 Please resolve this:
-1. Fetch the latest project branch: git fetch origin 2>/dev/null; git fetch . ${projectBranch}:${projectBranch} 2>/dev/null || true
-2. Rebase onto the project branch: git rebase ${projectBranch}
+1. Fetch the latest project branch: git fetch origin 2>/dev/null; git fetch . ${safeBranch}:${safeBranch} 2>/dev/null || true
+2. Rebase onto the project branch: git rebase ${safeBranch}
 3. For each conflict, open the file, resolve the conflict markers (<<<<<<< / ======= / >>>>>>>), keeping the correct combination of both changes
 4. Stage resolved files: git add <resolved-files>
 5. Continue the rebase: git rebase --continue
@@ -57,22 +63,24 @@ function buildPRConflictResolutionPrompt(
   attempt: number,
   maxAttempts: number,
 ): string {
+  const safeBranch = sanitizeGitRef(projectBranch);
+  const safeTaskBranch = sanitizeGitRef(branchName);
   return `MERGE CONFLICT DETECTED ON GITHUB (attempt ${attempt}/${maxAttempts})
 
 Your pull request cannot be automatically merged into the project branch because
 parallel tasks have modified overlapping files.
 
-Your task branch is: ${branchName}
-The target branch is: ${projectBranch}
+Your task branch is: ${safeTaskBranch}
+The target branch is: ${safeBranch}
 
 Please resolve this:
-1. Fetch the latest target branch: git fetch origin ${projectBranch}
-2. Rebase onto the target branch: git rebase origin/${projectBranch}
+1. Fetch the latest target branch: git fetch origin ${safeBranch}
+2. Rebase onto the target branch: git rebase origin/${safeBranch}
 3. For each conflict, open the file, resolve the conflict markers (<<<<<<< / ======= / >>>>>>>), keeping the correct combination of both changes
 4. Stage resolved files: git add <resolved-files>
 5. Continue the rebase: git rebase --continue
 6. Verify your changes still work (run a quick build/test if applicable)
-7. Force-push the rebased branch: git push --force-with-lease origin ${branchName}
+7. Force-push the rebased branch: git push --force-with-lease origin ${safeTaskBranch}
 
 IMPORTANT: Do NOT create a merge commit. Use rebase so the history is clean.
 After you force-push, I will automatically retry the GitHub merge.`;
@@ -199,18 +207,19 @@ async function simulatePRMergeRetry(opts: {
   const result: DeliveryResult = {};
   let prMergeResolved = false;
 
-  const resumable = isResumable
-    && !!adapter.getTaskContext(taskId)?.sessionId;
+  // Cache context once before the loop — mirrors real code (task-executor.ts:1324)
+  const prTaskContext = isResumable
+    ? adapter.getTaskContext(taskId)
+    : null;
 
-  if (resumable) {
+  if (prTaskContext?.sessionId) {
     for (let attempt = 1; attempt <= MAX_PR_MERGE_ATTEMPTS; attempt++) {
-      const context = adapter.getTaskContext(taskId)!;
       try {
         await adapter.resumeTask(
           taskId,
           buildPRConflictResolutionPrompt(opts.baseBranch, opts.branchName, attempt, MAX_PR_MERGE_ATTEMPTS),
           '/tmp/workdir',
-          context.sessionId,
+          prTaskContext.sessionId,
         );
       } catch (resumeErr) {
         result.deliveryStatus = 'failed';

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -34,6 +34,15 @@ import {
 const execFileAsync = promisify(execFileCb);
 
 /**
+ * Sanitize a git ref name for embedding in prompt shell commands.
+ * Strips characters that could enable command injection (;, $, `, |, &, etc.)
+ * while preserving valid git ref characters (alphanumeric, /, -, _, .).
+ */
+function sanitizeGitRef(ref: string): string {
+  return ref.replace(/[^a-zA-Z0-9/_.\-]/g, '');
+}
+
+/**
  * Build a prompt instructing the agent to resolve merge conflicts.
  * The agent's worktree has the task branch checked out; it needs to
  * rebase onto the project branch to resolve conflicts, then commit.
@@ -44,6 +53,7 @@ function buildConflictResolutionPrompt(
   attempt: number,
   maxAttempts: number,
 ): string {
+  const safeBranch = sanitizeGitRef(projectBranch);
   const fileList = conflictFiles.map(f => `- ${f}`).join('\n');
   return `MERGE CONFLICT DETECTED (attempt ${attempt}/${maxAttempts})
 
@@ -53,11 +63,11 @@ parallel tasks have modified overlapping files since you branched.
 Conflicting files:
 ${fileList}
 
-The project branch is: ${projectBranch}
+The project branch is: ${safeBranch}
 
 Please resolve this:
-1. Fetch the latest project branch: git fetch origin 2>/dev/null; git fetch . ${projectBranch}:${projectBranch} 2>/dev/null || true
-2. Rebase onto the project branch: git rebase ${projectBranch}
+1. Fetch the latest project branch: git fetch origin 2>/dev/null; git fetch . ${safeBranch}:${safeBranch} 2>/dev/null || true
+2. Rebase onto the project branch: git rebase ${safeBranch}
 3. For each conflict, open the file, resolve the conflict markers (<<<<<<< / ======= / >>>>>>>), keeping the correct combination of both changes
 4. Stage resolved files: git add <resolved-files>
 5. Continue the rebase: git rebase --continue
@@ -78,22 +88,24 @@ function buildPRConflictResolutionPrompt(
   attempt: number,
   maxAttempts: number,
 ): string {
+  const safeBranch = sanitizeGitRef(projectBranch);
+  const safeTaskBranch = sanitizeGitRef(branchName);
   return `MERGE CONFLICT DETECTED ON GITHUB (attempt ${attempt}/${maxAttempts})
 
 Your pull request cannot be automatically merged into the project branch because
 parallel tasks have modified overlapping files.
 
-Your task branch is: ${branchName}
-The target branch is: ${projectBranch}
+Your task branch is: ${safeTaskBranch}
+The target branch is: ${safeBranch}
 
 Please resolve this:
-1. Fetch the latest target branch: git fetch origin ${projectBranch}
-2. Rebase onto the target branch: git rebase origin/${projectBranch}
+1. Fetch the latest target branch: git fetch origin ${safeBranch}
+2. Rebase onto the target branch: git rebase origin/${safeBranch}
 3. For each conflict, open the file, resolve the conflict markers (<<<<<<< / ======= / >>>>>>>), keeping the correct combination of both changes
 4. Stage resolved files: git add <resolved-files>
 5. Continue the rebase: git rebase --continue
 6. Verify your changes still work (run a quick build/test if applicable)
-7. Force-push the rebased branch: git push --force-with-lease origin ${branchName}
+7. Force-push the rebased branch: git push --force-with-lease origin ${safeTaskBranch}
 
 IMPORTANT: Do NOT create a merge commit. Use rebase so the history is clean.
 After you force-push, I will automatically retry the GitHub merge.`;


### PR DESCRIPTION
## Summary

Parallel tasks in Astro's accumulative branch model inevitably produce merge conflicts — Task 2 branches from an old project branch tip and overlaps with Task 1's already-merged changes. Previously, these conflicts failed silently post-session. Now the AI agent resolves them itself via session resume, retrying up to 3 times in both local (`branch`) and GitHub (`pr`) delivery modes.

This is the critical missing piece for parallel task execution. The `BranchLockManager` (PR #64) serializes merge operations; this PR handles what happens when those merges conflict.

### What changed

- **Branch mode retry loop** — On local merge conflict, releases the lock, resumes the agent session with a conflict resolution prompt, agent rebases onto the project branch tip, retries merge (up to 3 attempts)
- **PR mode retry loop** — On GitHub auto-merge failure, resumes the agent session to rebase and force-push, retries `gh pr merge --squash` (up to 3 attempts)
- **Conflict resolution prompts** — `buildConflictResolutionPrompt()` (local) and `buildPRConflictResolutionPrompt()` (GitHub) with step-by-step rebase instructions
- **Dead code removal** — 1,290 lines of unused code removed (prompt-templates, repo-context, StreamingPrompt, SlurmAdapter, ssh-installer check, display helpers, provider factory)
- **88 tests** covering both retry loops, prompt correctness, edge cases, and provider fallback

---

## Why This Matters — Parallel Execution

The accumulative branch model has parallel tasks merging into a shared project branch:

```
main ── A ── B
              └── astro/7b19a9 (project branch)
                    ├── task-1 (worktree) ──→ squash merge ──→ tip moves forward
                    ├── task-2 (worktree) ──→ squash merge ──→ CONFLICT (branched from old tip)
                    └── task-3 (worktree) ──→ squash merge ──→ CONFLICT (same reason)
```

Task 2 and 3 branched before Task 1 merged. File overlap is the **normal case** for parallel tasks, not an edge case.

```
Previous (broken):
Task 1: [── execute ──][lock][merge ✓]
Task 2: [── execute ────────][lock][merge ✗ silent failure]

Now (working):
Task 1: [── execute ──][lock][merge ✓]
Task 2: [── execute ────────][lock][merge ✗ conflict][resume agent → resolve][lock][merge ✓]
```

Without this, parallel execution is a promise the system can't keep.

---

## Architecture

### Branch Mode (Local Git)

```mermaid
sequenceDiagram
    participant E as Executor
    participant L as BranchLockManager
    participant G as Git (local)
    participant A as Agent (session resume)

    Note over E: Agent execution complete
    loop Up to 3 attempts
        E->>L: acquire merge lock
        E->>G: squash-merge task→project
        alt Clean merge
            G-->>E: merged ✓
            E->>L: release lock
            Note over E: deliveryStatus = success
        else Conflict
            G-->>E: conflict (file list)
            E->>L: release lock
            Note over L: Lock FREE during resolution
            E->>A: resumeTask(conflict prompt)
            Note over A: Rebase onto project branch<br/>Resolve conflict markers<br/>git rebase --continue
            A-->>E: session complete
        end
    end
    Note over E: 3 failures → deliveryStatus = failed
```

Key: **Lock released during resolution** — agent may take minutes; lock held only during squash-merge (seconds).

### PR Mode (GitHub)

```mermaid
sequenceDiagram
    participant E as Executor
    participant GH as GitHub API
    participant A as Agent (session resume)

    Note over E: PR created, auto-merge failed
    loop Up to 3 attempts
        E->>A: resumeTask(PR conflict prompt)
        Note over A: git rebase origin/projectBranch<br/>Resolve conflicts<br/>git push --force-with-lease
        A-->>E: session complete
        E->>GH: gh pr merge --squash
        alt Merge succeeds
            GH-->>E: merged ✓
            Note over E: deliveryStatus = success
        else Still conflicts
            GH-->>E: merge failed
        end
    end
    Note over E: 3 failures → deliveryStatus = failed
```

### Provider Support

All 4 providers support session resume via `isResumableAdapter()`:

| Provider | Resume mechanism | Conflict resolution |
|---|---|---|
| Claude SDK | SDK `resume` with `sessionId` | Full support |
| Codex | `codex exec resume <threadId>` | Full support |
| OpenClaw | Generic CLI resume | Full support |
| OpenCode | Generic CLI resume | Full support |

Non-resumable adapters (or sessions without `sessionId`) fall back to immediate failure with conflict file list — same behavior as before.

---

## Conflict Resolution Prompts

Two prompts tailored to each mode:

| Prompt | Mode | Key difference |
|---|---|---|
| `buildConflictResolutionPrompt()` | Branch (local) | Fetches project branch locally: `git fetch . projectBranch:projectBranch` |
| `buildPRConflictResolutionPrompt()` | PR (GitHub) | Fetches from origin: `git fetch origin projectBranch`, ends with `git push --force-with-lease` |

Both instruct the agent to:
1. Fetch the latest target branch
2. Rebase (not merge) onto it
3. Resolve conflict markers
4. Stage and continue rebase
5. Verify changes still work

---

## Dead Code Removal (1,290 lines)

| File | Lines | Reason |
|---|---|---|
| `src/lib/prompt-templates.ts` | 432 | Stale copy of server prompts, never imported |
| `src/lib/repo-context.ts` | 145 | Server has own copy, agent-runner never calls it |
| `src/lib/streaming-prompt.ts` | 108 | Ported from Cyrus, never integrated |
| `src/providers/slurm-adapter.ts` | 161 | Replaced by SlurmStrategy |
| `src/lib/display.ts:formatBackgroundSummary()` | 19 | Exported, zero callers |
| `src/lib/ssh-installer.ts:checkRemoteAgentRunning()` | 13 | Only used in own test |
| `src/providers/index.ts:createCliProviderAdapter()` | 7 | Zero callers |
| `src/index.ts: SlurmAdapter export` | 1 | Barrel export for deleted file |
| Test files for deleted modules | 712 | Tests for prompt-templates, repo-context, ssh-installer-check |

---

## Edge Cases

| Scenario | Behavior |
|---|---|
| Two tasks modify same file, different lines | Git auto-resolves, no conflict |
| Two tasks modify same lines | Agent resolves via rebase, retry up to 3x |
| Three parallel tasks, cascading conflicts | Each resolved independently with own retry loop |
| Agent can't resolve after 3 attempts | `deliveryStatus='failed'`, chain halts for human review |
| Non-resumable adapter | Immediate failure with conflict file list (pre-existing behavior) |
| No sessionId on adapter | Not resumable, immediate failure |
| `localMerge` throws (not error object) | Lock still released via finally block |
| Resume itself throws | Caught, deliveryError set, loop breaks |
| Special characters in conflict file paths | Preserved exactly in error message |

---

## Test Plan (88 tests)

### Section 1: Branch mode delivery (11 tests)
- [x] Successful merge → `deliveryStatus='success'`, `commitAfterSha` captured
- [x] Conflict → `deliveryStatus='failed'`, conflict files listed
- [x] No changes → `deliveryStatus='skipped'`
- [x] Lock acquired/released around merge
- [x] Missing gitRoot/projectBranch → merge skipped

### Section 2: Branch mode conflict resolution (14 tests)
- [x] Resumable adapter: conflict → resume → retry → success
- [x] Non-resumable adapter: immediate failure
- [x] All 3 attempts fail → `deliveryStatus='failed'`
- [x] Lock released before resume, re-acquired for retry
- [x] Resume error → caught, deliveryError set
- [x] Three consecutive conflicts, each resolved, last succeeds

### Section 3: PR mode delivery (10 tests)
- [x] Successful merge → `deliveryStatus='success'`
- [x] Auto-merge failed → conflict handling triggered
- [x] Non-resumable → original failure message

### Section 4: PR mode conflict resolution (12 tests)
- [x] Resumable adapter: auto-merge fail → resume → retry → success
- [x] All 3 attempts fail → error includes attempt count
- [x] Resume error → deliveryError set
- [x] `commitAfterSha` updated from `getRemoteBranchSha` on success

### Section 5: Conflict resolution prompts (12 tests)
- [x] Branch prompt: all 6 steps present, uses local fetch
- [x] PR prompt: all 7 steps present, uses origin fetch, includes force-push
- [x] Attempt/max counters in both prompts
- [x] Branch refs correct in rebase commands

### Section 6: Prompt mirror verification (7 tests)
- [x] Numbered steps match actual workflow
- [x] Local vs origin fetch references correct

### Section 7-8: Additional edge cases (22 tests)
- [x] Error string preservation, lock release on throw, empty getRemoteSha
- [x] Multi-attempt failure includes all conflict files
- [x] getTaskContext called per attempt (fresh sessionId)

### CI
- [x] `npm run build` — PASS
- [x] `npm test` — 88/88 PASS (merge conflict resolution)

---

## Related

- **PR #64** (agent-runner) — Merge-only lock (`BranchLockManager`), narrows lock scope to seconds
- **PR #724** (astro) — Server-side prompt enhancements: Push to GitHub rebase instructions, parallel file separation, task description quality
- **Issue #719** (astro) — Local git accumulative merge design (closed by this + prior PRs)
- **Issue #722** (astro) — AI agent merge conflict resolution (closed by PR #724)

Generated with [Claude Code](https://claude.com/claude-code)