### PR TITLE
fix: unified execution summary generation across all provider adapters

### DIFF
--- a/src/providers/base-adapter.ts
+++ b/src/providers/base-adapter.ts
@@ -2,7 +2,7 @@
  * Base adapter interface for agent providers
  */
 
-import type { Task, TaskResult, TaskStatus } from '../types.js';
+import type { Task, TaskResult, TaskStatus, ExecutionSummary } from '../types.js';
 
 export interface TaskOutputStream {
   stdout: (data: string) => void;
@@ -48,6 +48,91 @@ export interface ProviderAdapter {
    * Get provider status/health
    */
   getStatus(): Promise<ProviderStatus>;
+
+  /**
+   * Generate a structured execution summary by resuming the completed session.
+   * The resumed session has full context of the work just performed, enabling
+   * high-quality summaries without re-reading files or logs.
+   *
+   * Optional — adapters that don't support session resume can omit this.
+   */
+  generateSummary?(taskId: string, workingDirectory?: string): Promise<ExecutionSummary | undefined>;
+}
+
+/**
+ * Shared summary prompt used by all adapters to generate structured execution summaries.
+ * Sent as a follow-up turn to the same session, so the agent has full context.
+ *
+ * Intentionally domain-agnostic — works for coding tasks, research analyses,
+ * data processing, and any other task type Astro supports.
+ */
+export const SUMMARY_PROMPT = `Produce a structured JSON summary of the work you just completed. Respond with ONLY a JSON object (no markdown fences, no extra text) matching this exact schema:
+
+{
+  "status": "success" | "partial" | "failure",
+  "workCompleted": "1-2 sentence summary of what was accomplished",
+  "executiveSummary": "1-2 paragraph executive summary: what was done, the approach taken, key decisions, and any trade-offs. Write in a clear, professional tone.",
+  "keyFindings": ["2-5 concise bullet points of key outcomes or observations (under 100 chars each)"],
+  "filesChanged": ["list of file paths that were created, modified, or deleted, or empty array if none"],
+  "followUps": ["suggested follow-up actions if any, or empty array"],
+  "prUrl": "full URL of the pull request if one was created, or null",
+  "prNumber": 123 or null,
+  "branchName": "git branch name if one was used, or null"
+}`;
+
+/** Timeout for summary generation (30 seconds) */
+export const SUMMARY_TIMEOUT_MS = 30_000;
+
+/**
+ * Create a no-op TaskOutputStream for internal use (e.g., summary generation).
+ * All stream methods are silent; approvalRequest returns { answered: false }.
+ */
+export function createNoopStream(): TaskOutputStream {
+  return {
+    stdout: () => {},
+    stderr: () => {},
+    status: () => {},
+    toolTrace: () => {},
+    text: () => {},
+    toolUse: () => {},
+    toolResult: () => {},
+    fileChange: () => {},
+    sessionInit: () => {},
+    approvalRequest: () => Promise.resolve({ answered: false }),
+  };
+}
+
+/**
+ * Parse a summary JSON response, stripping markdown code fences if present.
+ * Returns undefined if the text is empty or not valid JSON.
+ */
+export function parseSummaryResponse(text: string, logPrefix: string): ExecutionSummary | undefined {
+  if (!text) {
+    console.warn(`${logPrefix}: no text output from summary generation`);
+    return undefined;
+  }
+
+  let jsonText = text.trim();
+  if (jsonText.startsWith('```')) {
+    jsonText = jsonText.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+  }
+
+  // Extract first JSON object if surrounded by other text
+  const jsonMatch = jsonText.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    jsonText = jsonMatch[0];
+  }
+
+  try {
+    const parsed = JSON.parse(jsonText) as ExecutionSummary;
+    if (!parsed.executiveSummary) {
+      console.warn(`${logPrefix}: summary generated but executiveSummary is missing. Keys: ${Object.keys(parsed).join(', ')}`);
+    }
+    return parsed;
+  } catch {
+    console.warn(`${logPrefix}: summary text was not valid JSON. Text: ${jsonText.slice(0, 300)}`);
+    return undefined;
+  }
 }
 
 export interface ProviderStatus {

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -40,7 +40,7 @@ function resolveClaudeExecutable(): string | undefined {
 const claudeExecutablePath = resolveClaudeExecutable();
 import type { Task, TaskResult, TaskArtifact, ExecutionSummary, HpcCapability } from '../types.js';
 import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
-import type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
+import { type ProviderAdapter, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse } from './base-adapter.js';
 import { buildHpcContext, type HpcContext } from '../lib/hpc-context.js';
 import type { SlurmJobMonitor } from '../lib/slurm-job-monitor.js';
 import { config } from '../lib/config.js';
@@ -519,9 +519,9 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
    * it returns errors with no structured_output. Instead, we embed the JSON format
    * in the prompt and parse the text response.
    */
-  private async generateSummary(
+  async generateSummary(
     taskId: string,
-    workingDirectory: string | undefined,
+    workingDirectory?: string,
   ): Promise<ExecutionSummary | undefined> {
     const sessionContext = this.activeQueries.get(taskId);
     if (!sessionContext?.sessionId) {
@@ -530,7 +530,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     }
 
     const summaryAbort = new AbortController();
-    const summaryTimeout = setTimeout(() => summaryAbort.abort(), 30_000);
+    const summaryTimeout = setTimeout(() => summaryAbort.abort(), SUMMARY_TIMEOUT_MS);
 
     try {
       // Ensure CLAUDE_CONFIG_DIR is set
@@ -549,22 +549,8 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       // Resume the execution session so the model has full context
       (options as Record<string, unknown>).resume = sessionContext.sessionId;
 
-      const summaryPrompt = `Produce a structured JSON summary of the work you just completed. Respond with ONLY a JSON object (no markdown fences, no extra text) matching this exact schema:
-
-{
-  "status": "success" | "partial" | "failure",
-  "workCompleted": "1-2 sentence summary of what was accomplished",
-  "executiveSummary": "1-2 paragraph executive summary for the PR description: what was done, the approach taken, key design decisions, and any trade-offs. Write in a professional tone suitable for code reviewers.",
-  "keyFindings": ["2-5 concise bullet points (under 100 chars each)"],
-  "filesChanged": ["list of file paths that were created, modified, or deleted"],
-  "followUps": ["suggested follow-up actions if any, or empty array"],
-  "prUrl": "full URL of the pull request if you created one, or null",
-  "prNumber": 123 or null,
-  "branchName": "git branch name you worked on, or null"
-}`;
-
       const gen = query({
-        prompt: summaryPrompt,
+        prompt: SUMMARY_PROMPT,
         options,
       });
 
@@ -590,27 +576,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
         }
       }
 
-      if (!textOutput) {
-        console.warn(`[claude-sdk] Task ${taskId}: no text output from summary generation`);
-        return undefined;
-      }
-
-      // Strip markdown code fences if present
-      let jsonText = textOutput.trim();
-      if (jsonText.startsWith('```')) {
-        jsonText = jsonText.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
-      }
-
-      try {
-        const parsed = JSON.parse(jsonText) as ExecutionSummary;
-        if (!parsed.executiveSummary) {
-          console.warn(`[claude-sdk] Task ${taskId}: summary generated but executiveSummary is missing. Keys: ${Object.keys(parsed).join(', ')}`);
-        }
-        return parsed;
-      } catch {
-        console.warn(`[claude-sdk] Task ${taskId}: summary text was not valid JSON. Text: ${jsonText.slice(0, 300)}`);
-        return undefined;
-      }
+      return parseSummaryResponse(textOutput, `[claude-sdk] Task ${taskId}`);
     } finally {
       clearTimeout(summaryTimeout);
     }

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -9,8 +9,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
-import type { Task, TaskResult, TaskArtifact } from '../types.js';
-import type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
+import type { Task, TaskResult, TaskArtifact, ExecutionSummary } from '../types.js';
+import { type ProviderAdapter, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse, createNoopStream } from './base-adapter.js';
 import { getProvider } from '../lib/providers.js';
 
 /** Metrics shape extracted from TaskResult (non-optional) */
@@ -39,8 +39,8 @@ interface ExecutionState {
   threadId?: string;
 }
 
-/** Session TTL: 30 minutes */
-const SESSION_TTL_MS = 30 * 60 * 1000;
+/** Session TTL: 10 minutes */
+const SESSION_TTL_MS = 10 * 60 * 1000;
 
 export class CodexAdapter implements ProviderAdapter {
   readonly type = 'codex';
@@ -119,6 +119,23 @@ export class CodexAdapter implements ProviderAdapter {
       // Build metrics from accumulated stream data + result model.
       const finalMetrics = this.buildFinalMetrics(result.model, startedAt, execState);
 
+      // Generate structured summary for execution tasks via a follow-up session resume.
+      let summary: ExecutionSummary | undefined;
+      const isExecutionTask = !task.type || task.type === 'execution';
+      if (isExecutionTask && result.exitCode === 0) {
+        try {
+          stream.status('running', 80, 'Generating summary');
+          summary = await this.generateSummary(task.id, task.workingDirectory);
+          if (summary) {
+            console.log(`[codex] Task ${task.id}: summary generated — status=${summary.status}, keyFindings=${summary.keyFindings?.length ?? 0}`);
+          } else {
+            console.warn(`[codex] Task ${task.id}: summary generation returned undefined`);
+          }
+        } catch (summaryError) {
+          console.warn(`[codex] Task ${task.id}: summary generation failed:`, summaryError);
+        }
+      }
+
       return {
         taskId: task.id,
         status: result.exitCode === 0 ? 'completed' : 'failed',
@@ -129,6 +146,7 @@ export class CodexAdapter implements ProviderAdapter {
         completedAt: new Date().toISOString(),
         artifacts: result.artifacts,
         metrics: finalMetrics,
+        summary,
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -321,6 +339,59 @@ export class CodexAdapter implements ProviderAdapter {
         });
       });
     });
+  }
+
+  /**
+   * Generate a structured execution summary by resuming the completed Codex session.
+   * Uses `codex exec resume <threadId> <summaryPrompt> --json` to ask for a JSON summary.
+   */
+  async generateSummary(taskId: string, workingDirectory?: string): Promise<ExecutionSummary | undefined> {
+    const session = this.activeSessions.get(taskId);
+    if (!session?.threadId) {
+      console.log(`[codex] No session to resume for summary (task ${taskId})`);
+      return undefined;
+    }
+
+    const summaryAbort = new AbortController();
+    const summaryTimeout = setTimeout(() => summaryAbort.abort(), SUMMARY_TIMEOUT_MS);
+
+    try {
+      const result = await this.resumeTask(
+        taskId,
+        SUMMARY_PROMPT,
+        workingDirectory || session.workingDirectory || '',
+        session.threadId,
+        createNoopStream(),
+        summaryAbort.signal as AbortSignal,
+      );
+
+      if (!result.success || !result.output) {
+        console.warn(`[codex] Task ${taskId}: summary resume failed — success=${result.success}, error=${result.error}`);
+        return undefined;
+      }
+
+      // Extract text content from JSONL output — look for agent_message items
+      let textContent = '';
+      for (const line of result.output.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as Record<string, unknown>;
+          if (event.type === 'item.completed') {
+            const item = event.item as Record<string, unknown> | undefined;
+            if (item?.type === 'agent_message' && typeof item.text === 'string') {
+              textContent += item.text;
+            }
+          }
+        } catch {
+          // Not JSON — could be raw text output
+          textContent += line;
+        }
+      }
+
+      return parseSummaryResponse(textContent || result.output, `[codex] Task ${taskId}`);
+    } finally {
+      clearTimeout(summaryTimeout);
+    }
   }
 
   private async runCodex(

--- a/src/providers/openclaw-adapter.ts
+++ b/src/providers/openclaw-adapter.ts
@@ -21,8 +21,8 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import WebSocket from 'ws';
-import type { Task, TaskResult, TaskArtifact } from '../types.js';
-import type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
+import type { Task, TaskResult, TaskArtifact, ExecutionSummary } from '../types.js';
+import { type ProviderAdapter, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse, createNoopStream } from './base-adapter.js';
 
 // ---------------------------------------------------------------------------
 // Types — OpenClaw Gateway Protocol v3
@@ -63,8 +63,8 @@ interface PreservedSession {
   createdAt: number;
 }
 
-/** TTL for preserved sessions (30 minutes) */
-const SESSION_TTL_MS = 30 * 60 * 1000;
+/** TTL for preserved sessions (10 minutes) */
+const SESSION_TTL_MS = 10 * 60 * 1000;
 
 export class OpenClawAdapter implements ProviderAdapter {
   readonly type = 'openclaw';
@@ -149,6 +149,24 @@ export class OpenClawAdapter implements ProviderAdapter {
         });
       }
 
+      // Generate structured summary for execution tasks via session resume
+      let summary: ExecutionSummary | undefined;
+      const isExecutionTask = !task.type || task.type === 'execution';
+      const succeeded = !isCancelled && !result.error;
+      if (isExecutionTask && succeeded) {
+        try {
+          stream.status('running', 80, 'Generating summary');
+          summary = await this.generateSummary(task.id, task.workingDirectory);
+          if (summary) {
+            console.log(`[openclaw] Task ${task.id}: summary generated — status=${summary.status}, keyFindings=${summary.keyFindings?.length ?? 0}`);
+          } else {
+            console.warn(`[openclaw] Task ${task.id}: summary generation returned undefined`);
+          }
+        } catch (summaryError) {
+          console.warn(`[openclaw] Task ${task.id}: summary generation failed:`, summaryError);
+        }
+      }
+
       return {
         taskId: task.id,
         status: isCancelled ? 'cancelled' : result.error ? 'failed' : 'completed',
@@ -158,6 +176,7 @@ export class OpenClawAdapter implements ProviderAdapter {
         completedAt: new Date().toISOString(),
         artifacts: result.artifacts,
         metrics: result.metrics,
+        summary,
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -292,6 +311,51 @@ export class OpenClawAdapter implements ProviderAdapter {
       if (now - session.createdAt > SESSION_TTL_MS) {
         this.preservedSessions.delete(key);
       }
+    }
+  }
+
+  // ─── Summary Generation ──────────────────────────────────────
+
+  /**
+   * Generate a structured execution summary by resuming the completed OpenClaw session.
+   * Sends the summary prompt to the same session key via chat.send.
+   */
+  async generateSummary(taskId: string, workingDirectory?: string): Promise<ExecutionSummary | undefined> {
+    const session = this.preservedSessions.get(taskId);
+    if (!session?.sessionKey) {
+      console.log(`[openclaw] No session to resume for summary (task ${taskId})`);
+      return undefined;
+    }
+
+    if (!this.gatewayConfig) {
+      const available = await this.isAvailable();
+      if (!available || !this.gatewayConfig) {
+        console.warn(`[openclaw] Gateway not available for summary generation (task ${taskId})`);
+        return undefined;
+      }
+    }
+
+    const summaryAbort = new AbortController();
+    const summaryTimeout = setTimeout(() => summaryAbort.abort(), SUMMARY_TIMEOUT_MS);
+
+    try {
+      const result = await this.resumeTask(
+        taskId,
+        SUMMARY_PROMPT,
+        workingDirectory || session.workingDirectory || '',
+        session.sessionKey,
+        createNoopStream(),
+        summaryAbort.signal,
+      );
+
+      if (!result.success || !result.output) {
+        console.warn(`[openclaw] Task ${taskId}: summary resume failed — success=${result.success}, error=${result.error}`);
+        return undefined;
+      }
+
+      return parseSummaryResponse(result.output, `[openclaw] Task ${taskId}`);
+    } finally {
+      clearTimeout(summaryTimeout);
     }
   }
 

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -14,8 +14,8 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { Task, TaskResult, TaskArtifact } from '../types.js';
-import type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
+import type { Task, TaskResult, TaskArtifact, ExecutionSummary } from '../types.js';
+import { type ProviderAdapter, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse, createNoopStream } from './base-adapter.js';
 import { getProvider } from '../lib/providers.js';
 
 /** Preserved session info for multi-turn resume */
@@ -26,8 +26,8 @@ interface PreservedSession {
   createdAt: number;
 }
 
-/** TTL for preserved sessions (30 minutes) */
-const SESSION_TTL_MS = 30 * 60 * 1000;
+/** TTL for preserved sessions (10 minutes) */
+const SESSION_TTL_MS = 10 * 60 * 1000;
 
 export class OpenCodeAdapter implements ProviderAdapter {
   readonly type = 'opencode';
@@ -108,6 +108,26 @@ export class OpenCodeAdapter implements ProviderAdapter {
         });
       }
 
+      // Save metrics before summary generation (resumeTask resets this.lastResultMetrics)
+      const savedMetrics = this.lastResultMetrics;
+
+      // Generate structured summary for execution tasks via session resume
+      let summary: ExecutionSummary | undefined;
+      const isExecutionTask = !task.type || task.type === 'execution';
+      if (isExecutionTask && succeeded) {
+        try {
+          stream.status('running', 80, 'Generating summary');
+          summary = await this.generateSummary(task.id, task.workingDirectory);
+          if (summary) {
+            console.log(`[opencode] Task ${task.id}: summary generated — status=${summary.status}, keyFindings=${summary.keyFindings?.length ?? 0}`);
+          } else {
+            console.warn(`[opencode] Task ${task.id}: summary generation returned undefined`);
+          }
+        } catch (summaryError) {
+          console.warn(`[opencode] Task ${task.id}: summary generation failed:`, summaryError);
+        }
+      }
+
       return {
         taskId: task.id,
         status: succeeded ? 'completed' : 'failed',
@@ -117,7 +137,8 @@ export class OpenCodeAdapter implements ProviderAdapter {
         startedAt,
         completedAt: new Date().toISOString(),
         artifacts: result.artifacts,
-        metrics: this.lastResultMetrics,
+        metrics: savedMetrics,
+        summary,
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -246,6 +267,64 @@ export class OpenCodeAdapter implements ProviderAdapter {
       if (now - session.createdAt > SESSION_TTL_MS) {
         this.preservedSessions.delete(key);
       }
+    }
+  }
+
+  // ─── Summary Generation ──────────────────────────────────────
+
+  /**
+   * Generate a structured execution summary by resuming the completed OpenCode session.
+   * Uses `opencode run --session <id> --print --output-format json` with the summary prompt.
+   */
+  async generateSummary(taskId: string, workingDirectory?: string): Promise<ExecutionSummary | undefined> {
+    const session = this.preservedSessions.get(taskId);
+    if (!session?.sessionId) {
+      console.log(`[opencode] No session to resume for summary (task ${taskId})`);
+      return undefined;
+    }
+
+    const summaryAbort = new AbortController();
+    const summaryTimeout = setTimeout(() => summaryAbort.abort(), SUMMARY_TIMEOUT_MS);
+
+    try {
+      const result = await this.resumeTask(
+        taskId,
+        SUMMARY_PROMPT,
+        workingDirectory || session.workingDirectory || '',
+        session.sessionId,
+        createNoopStream(),
+        summaryAbort.signal,
+      );
+
+      if (!result.success || !result.output) {
+        console.warn(`[opencode] Task ${taskId}: summary resume failed — success=${result.success}, error=${result.error}`);
+        return undefined;
+      }
+
+      // Extract text from JSONL output — look for assistant text blocks
+      let textContent = '';
+      for (const line of result.output.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as Record<string, unknown>;
+          if (event.type === 'assistant') {
+            const content = (event.content || (event.message as Record<string, unknown>)?.content) as Array<{ type: string; text?: string }> | undefined;
+            if (content) {
+              for (const block of content) {
+                if (block.type === 'text' && block.text) {
+                  textContent += block.text;
+                }
+              }
+            }
+          }
+        } catch {
+          textContent += line;
+        }
+      }
+
+      return parseSummaryResponse(textContent || result.output, `[opencode] Task ${taskId}`);
+    } finally {
+      clearTimeout(summaryTimeout);
     }
   }
 

--- a/tests/openclaw-gateway-adapter.test.ts
+++ b/tests/openclaw-gateway-adapter.test.ts
@@ -230,9 +230,14 @@ describe('OpenClaw Gateway Adapter', () => {
       const stream = createMockStream()
       const controller = new AbortController()
       let capturedMessage = ''
+      let callCount = 0
 
       gateway.onChatSend = (params, ws) => {
-        capturedMessage = params.message as string
+        callCount++
+        // Capture only the first chat.send (the task prompt), not follow-up summary
+        if (callCount === 1) {
+          capturedMessage = params.message as string
+        }
         const sessionKey = params.sessionKey as string
         const runId = 'run-test'
 

--- a/tests/summary-utils.test.ts
+++ b/tests/summary-utils.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for shared summary utilities in base-adapter.ts:
+ * - parseSummaryResponse: JSON parsing with code fence stripping
+ * - SUMMARY_PROMPT: prompt constant validation
+ * - SUMMARY_TIMEOUT_MS: timeout constant
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSummaryResponse, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, createNoopStream } from '../src/providers/base-adapter.js';
+
+describe('SUMMARY_PROMPT', () => {
+  it('is a non-empty string', () => {
+    expect(typeof SUMMARY_PROMPT).toBe('string');
+    expect(SUMMARY_PROMPT.length).toBeGreaterThan(100);
+  });
+
+  it('requests JSON output with all required fields', () => {
+    expect(SUMMARY_PROMPT).toContain('JSON');
+    expect(SUMMARY_PROMPT).toContain('"status"');
+    expect(SUMMARY_PROMPT).toContain('"workCompleted"');
+    expect(SUMMARY_PROMPT).toContain('"executiveSummary"');
+    expect(SUMMARY_PROMPT).toContain('"keyFindings"');
+    expect(SUMMARY_PROMPT).toContain('"filesChanged"');
+    expect(SUMMARY_PROMPT).toContain('"followUps"');
+    expect(SUMMARY_PROMPT).toContain('"prUrl"');
+    expect(SUMMARY_PROMPT).toContain('"prNumber"');
+    expect(SUMMARY_PROMPT).toContain('"branchName"');
+  });
+
+  it('is domain-agnostic (not specialized to coding)', () => {
+    // Should NOT contain language that assumes coding context
+    expect(SUMMARY_PROMPT).not.toContain('code reviewers');
+    expect(SUMMARY_PROMPT).not.toContain('PR description');
+  });
+});
+
+describe('SUMMARY_TIMEOUT_MS', () => {
+  it('is 30 seconds', () => {
+    expect(SUMMARY_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+describe('parseSummaryResponse', () => {
+  const prefix = '[test]';
+
+  it('parses a valid JSON summary', () => {
+    const json = JSON.stringify({
+      status: 'success',
+      workCompleted: 'Implemented the feature',
+      executiveSummary: 'A detailed summary of the work.',
+      keyFindings: ['Added API endpoint', 'Updated tests'],
+      filesChanged: ['src/api.ts', 'tests/api.test.ts'],
+      followUps: ['Monitor performance'],
+      prUrl: 'https://github.com/org/repo/pull/42',
+      prNumber: 42,
+      branchName: 'feat/new-api',
+    });
+
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('success');
+    expect(result!.workCompleted).toBe('Implemented the feature');
+    expect(result!.executiveSummary).toBe('A detailed summary of the work.');
+    expect(result!.keyFindings).toEqual(['Added API endpoint', 'Updated tests']);
+    expect(result!.filesChanged).toEqual(['src/api.ts', 'tests/api.test.ts']);
+    expect(result!.followUps).toEqual(['Monitor performance']);
+    expect(result!.prUrl).toBe('https://github.com/org/repo/pull/42');
+    expect(result!.prNumber).toBe(42);
+    expect(result!.branchName).toBe('feat/new-api');
+  });
+
+  it('strips markdown json code fences', () => {
+    const json = '```json\n{"status":"success","workCompleted":"Done","executiveSummary":"Summary","keyFindings":[],"filesChanged":[],"followUps":[]}\n```';
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('success');
+  });
+
+  it('strips plain code fences', () => {
+    const json = '```\n{"status":"partial","workCompleted":"Halfway","executiveSummary":"Partial work","keyFindings":[],"filesChanged":[],"followUps":[]}\n```';
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('partial');
+  });
+
+  it('extracts JSON from surrounding text', () => {
+    const text = 'Here is the summary:\n{"status":"failure","workCompleted":"Failed to build","executiveSummary":"Build errors","keyFindings":["Build failed"],"filesChanged":[],"followUps":["Fix build"]}\nDone.';
+    const result = parseSummaryResponse(text, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('failure');
+    expect(result!.workCompleted).toBe('Failed to build');
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseSummaryResponse('', prefix)).toBeUndefined();
+  });
+
+  it('returns undefined for invalid JSON', () => {
+    expect(parseSummaryResponse('{ this is not: valid json !!! }', prefix)).toBeUndefined();
+  });
+
+  it('returns undefined for non-JSON text', () => {
+    expect(parseSummaryResponse('Just some plain text without any JSON', prefix)).toBeUndefined();
+  });
+
+  it('handles JSON with whitespace', () => {
+    const json = `
+    {
+      "status": "success",
+      "workCompleted": "Spaced out",
+      "executiveSummary": "With lots of whitespace",
+      "keyFindings": [],
+      "filesChanged": [],
+      "followUps": []
+    }
+    `;
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('success');
+  });
+
+  it('warns when executiveSummary is missing but still returns result', () => {
+    const json = JSON.stringify({
+      status: 'success',
+      workCompleted: 'Done',
+      keyFindings: [],
+      filesChanged: [],
+      followUps: [],
+    });
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('success');
+    expect(result!.executiveSummary).toBeUndefined();
+  });
+
+  it('handles partial status', () => {
+    const json = JSON.stringify({
+      status: 'partial',
+      workCompleted: 'Partially done',
+      executiveSummary: 'Work in progress.',
+      keyFindings: ['Started implementation'],
+      filesChanged: ['src/index.ts'],
+      followUps: ['Complete remaining work'],
+    });
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('partial');
+  });
+
+  it('handles failure status', () => {
+    const json = JSON.stringify({
+      status: 'failure',
+      workCompleted: 'Could not complete',
+      executiveSummary: 'Failed due to errors.',
+      keyFindings: ['Build errors'],
+      filesChanged: [],
+      followUps: ['Fix the build'],
+    });
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.status).toBe('failure');
+  });
+
+  it('handles null prUrl and prNumber', () => {
+    const json = JSON.stringify({
+      status: 'success',
+      workCompleted: 'Done',
+      executiveSummary: 'Summary',
+      keyFindings: [],
+      filesChanged: [],
+      followUps: [],
+      prUrl: null,
+      prNumber: null,
+      branchName: null,
+    });
+    const result = parseSummaryResponse(json, prefix);
+    expect(result).not.toBeUndefined();
+    expect(result!.prUrl).toBeNull();
+    expect(result!.prNumber).toBeNull();
+    expect(result!.branchName).toBeNull();
+  });
+});
+
+describe('createNoopStream', () => {
+  it('returns an object with all TaskOutputStream methods', () => {
+    const stream = createNoopStream();
+    expect(typeof stream.stdout).toBe('function');
+    expect(typeof stream.stderr).toBe('function');
+    expect(typeof stream.status).toBe('function');
+    expect(typeof stream.toolTrace).toBe('function');
+    expect(typeof stream.text).toBe('function');
+    expect(typeof stream.toolUse).toBe('function');
+    expect(typeof stream.toolResult).toBe('function');
+    expect(typeof stream.fileChange).toBe('function');
+    expect(typeof stream.sessionInit).toBe('function');
+    expect(typeof stream.approvalRequest).toBe('function');
+  });
+
+  it('approvalRequest returns { answered: false }', async () => {
+    const stream = createNoopStream();
+    const result = await stream.approvalRequest('question', ['yes', 'no']);
+    expect(result).toEqual({ answered: false });
+  });
+
+  it('all methods are callable without errors', () => {
+    const stream = createNoopStream();
+    expect(() => stream.stdout('test')).not.toThrow();
+    expect(() => stream.stderr('test')).not.toThrow();
+    expect(() => stream.status('running', 50, 'msg')).not.toThrow();
+    expect(() => stream.text('data')).not.toThrow();
+    expect(() => stream.toolUse('tool', {})).not.toThrow();
+    expect(() => stream.toolResult('tool', '', true)).not.toThrow();
+    expect(() => stream.fileChange('path', 'created')).not.toThrow();
+    expect(() => stream.sessionInit('sid')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- All 4 provider adapters (Claude SDK, Codex, OpenCode, OpenClaw) now generate structured `ExecutionSummary` via session resume after task completion
- Previously only Claude SDK generated summaries, leaving non-Claude providers without structured data for replan context, knowledge extraction, and PR descriptions
- Fixes [astro#765](https://github.com/fuxialexander/astro/issues/765)

## Changes

### Shared infrastructure (`base-adapter.ts`)
- `SUMMARY_PROMPT` — domain-agnostic prompt that works for coding, research, and analysis tasks
- `SUMMARY_TIMEOUT_MS` — 30-second timeout constant
- `parseSummaryResponse()` — JSON parser with code fence stripping and text extraction
- `createNoopStream()` — silent `TaskOutputStream` factory for internal resume calls
- Optional `generateSummary?()` added to `ProviderAdapter` interface

### Per-adapter implementation
- **Codex**: `generateSummary()` resumes session via `codex exec resume <threadId>`, extracts JSON from `agent_message` JSONL events
- **OpenCode**: `generateSummary()` resumes via `opencode run --session <id>`, extracts JSON from `assistant` text blocks
- **OpenClaw**: `generateSummary()` resumes via `chat.send` on same session key, parses direct text output
- **Claude SDK**: Refactored to use shared `SUMMARY_PROMPT`, `SUMMARY_TIMEOUT_MS`, and `parseSummaryResponse()` (eliminates duplication)

### Bug fixes
- **OpenCode metrics corruption**: `resumeTask()` resets `this.lastResultMetrics`, which corrupted the returned `TaskResult.metrics`. Fixed by saving metrics to a local variable before calling `generateSummary()`
- **Session TTL standardized**: Changed from 30 min to 10 min across Codex, OpenCode, and OpenClaw adapters

### Tests
- 19 new tests in `tests/summary-utils.test.ts` for shared parsing utilities, prompt validation, `createNoopStream`
- Fixed `tests/openclaw-gateway-adapter.test.ts` to capture only the first `chat.send` (not the follow-up summary resume)

## Design decisions

1. **Adapter-level, not server-level** — Each adapter generates summaries by resuming its own session. The resumed session has full execution context (files read, tools used, errors encountered), producing higher-quality summaries than a server-side approach that only sees raw output text.

2. **Domain-agnostic prompt** — The summary prompt doesn't assume coding context. It works for research analyses, data processing, and any other task type Astro supports. Fields like `prUrl`/`branchName` are optional and null when not applicable.

3. **Fire-and-fail-safe** — Summary generation is wrapped in try/catch within `execute()`. A summary failure never blocks or corrupts the task result.

## Test plan

- [x] `npm run build` — TypeScript compilation passes
- [x] `npx vitest run` — 563 tests pass across 30 test files
- [x] AI code review identified and fixed critical metrics corruption bug
- [ ] Integration test: run a task with Codex/OpenCode/OpenClaw and verify `result.summary` is populated

Generated with [Claude Code](https://claude.ai/code)