### PR TITLE
feat: add follow-up task type for resumed execution with delivery

### DIFF
--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -267,8 +267,8 @@ export class TaskExecutor {
     storedAt: number;
   }> = new Map();
 
-  /** TTL for completed task metadata (10 minutes, matches adapter session TTL) */
-  private static readonly COMPLETED_TASK_META_TTL_MS = 10 * 60 * 1000;
+  /** TTL for completed task metadata (30 minutes, allows follow-up execution to recreate worktrees) */
+  private static readonly COMPLETED_TASK_META_TTL_MS = 30 * 60 * 1000;
 
   constructor(options: TaskExecutorOptions) {
     this.wsClient = options.wsClient;
@@ -326,11 +326,11 @@ export class TaskExecutor {
     this.claimedTasks.add(task.id);
     try {
 
-    // Only execution tasks need workingDirectory resolution, safety checks,
+    // Execution and follow-up tasks need workingDirectory resolution, safety checks,
     // git diff, and summary generation. All other types (plan/chat/summarize/
     // playground) skip this overhead but still get full tool access when they
     // have a working directory.
-    const isExecutionTask = !task.type || task.type === 'execution';
+    const isExecutionTask = !task.type || task.type === 'execution' || task.type === 'follow-up';
 
     // Non-execution tasks can run without a working directory.
     // For execution tasks, resolve the directory or auto-provision one.
@@ -1163,9 +1163,9 @@ export class TaskExecutor {
       );
     }, TASK_HEARTBEAT_INTERVAL_MS);
 
-    // Only execution tasks get git diff, delivery, and summary — all other types (chat, plan, playground, summarize) skip them.
+    // Execution and follow-up tasks get git diff, delivery, and summary — all other types (chat, plan, playground, summarize) skip them.
     // These non-execution types still get full tool access when they have a working directory.
-    const isExecutionTask = !normalizedTask.type || normalizedTask.type === 'execution';
+    const isExecutionTask = !normalizedTask.type || normalizedTask.type === 'execution' || normalizedTask.type === 'follow-up';
     let prepared: Awaited<ReturnType<typeof this.prepareTaskWorkspace>>;
     try {
       prepared = !isExecutionTask && !normalizedTask.workingDirectory
@@ -1205,10 +1205,11 @@ export class TaskExecutor {
       // Notify task started
       this.wsClient.sendTaskStatus(task.id, 'running', 0, 'Starting');
 
-      // Resume existing session if resumeSessionId is provided
+      // Resume existing session if resumeSessionId is provided.
+      // Follow-up tasks are treated as execution (get delivery pipeline) but also allow session resume.
       const canResume = taskWithWorkspace.resumeSessionId
         && this.isResumableAdapter(adapter)
-        && !isExecutionTask;
+        && (!isExecutionTask || normalizedTask.type === 'follow-up');
 
       let result: Awaited<ReturnType<typeof adapter.execute>>;
       if (canResume) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export type TaskStatus =
  * Dispatch task type — tells the agent runner what kind of work this is.
  * Matches TaskDispatchType in server/types/relay.ts.
  */
-export type TaskDispatchType = 'execution' | 'plan' | 'chat' | 'summarize' | 'playground';
+export type TaskDispatchType = 'execution' | 'plan' | 'chat' | 'summarize' | 'playground' | 'follow-up';
 
 /**
  * A single message in a conversation history.


### PR DESCRIPTION
## Summary
- Adds `'follow-up'` to `TaskDispatchType` union so follow-up messages on completed tasks dispatch as full executions with worktree isolation and delivery pipeline
- Treats follow-up tasks as execution tasks (worktree creation, git diff, delivery) while also allowing session resume (previously these were mutually exclusive)
- Increases `completedTaskMeta` TTL from 10 to 30 minutes to allow follow-up worktree recreation

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Existing tests pass
- [ ] Follow-up dispatch creates worktree and runs delivery pipeline
- [ ] Session resume works for follow-up tasks when session is still alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)