### PR TITLE
fix: prevent false auto-verify when Claude Code exits with non-zero code

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -716,6 +716,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     let success = false;
     let errorMessage: string | undefined;
     let resultMetrics: TaskResult['metrics'] | undefined;
+    let receivedResult = false;
 
     for await (const msg of gen) {
       if (msg.type === 'system' && msg.subtype === 'init') {
@@ -751,13 +752,15 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           errorMessage = `Task failed: ${msg.subtype}`;
           stream.status('failed', 0, errorMessage);
         }
+        receivedResult = true;
         break;
       }
     }
 
     // If the stream ended without a result message, treat as failure
-    if (!success && !errorMessage) {
-      errorMessage = 'Agent process exited without producing a result message';
+    if (!receivedResult) {
+      success = false;
+      errorMessage ??= 'Agent process exited without producing a result message';
       stream.status('failed', 0, errorMessage);
     }
 
@@ -1104,6 +1107,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
     let turnIndex = 0;
     let receivedResult = false;
+    let lastResultSubtype: string | undefined;
 
     for await (const msg of gen) {
       try {
@@ -1216,6 +1220,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       } else if (msg.type === 'result') {
         // Extract metrics from SDK result (available on both success and error subtypes)
         const msgAny = msg as Record<string, unknown>;
+        lastResultSubtype = msg.subtype;
         const usage = msgAny.usage as { input_tokens?: number; output_tokens?: number } | undefined;
         const totalCostUsd = (msgAny.total_cost_usd ?? msgAny.cost_usd) as number | undefined;
         const numTurns = msgAny.num_turns as number | undefined;
@@ -1266,9 +1271,10 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           errorMessage = `Task failed: ${msg.subtype}`;
           stream.status('failed', progress, errorMessage);
         } else {
-          // Unrecognized result subtype — treat as failure with descriptive message
+          // Unrecognized result subtype — treat as failure with descriptive message.
+          // Likely a Claude Code version mismatch or new SDK error subtype.
           success = false;
-          errorMessage = `Task ended with unrecognized result: ${msg.subtype}`;
+          errorMessage = `Task ended with unrecognized SDK result subtype: ${msg.subtype} — this may indicate a Claude Code version mismatch or SDK change`;
           stream.status('failed', progress, errorMessage);
         }
 
@@ -1285,7 +1291,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       }
     }
 
-    console.log(`[claude-sdk] Task ${task.id} for-await loop exited: ${receivedResult ? 'received result message (normal)' : 'generator exhausted without result message'}`);
+    console.log(`[claude-sdk] Task ${task.id} for-await loop exited: ${receivedResult ? `received result message (subtype=${lastResultSubtype ?? 'unknown'})` : 'generator exhausted without result message'}`);
 
     // If the stream ended without a result message, the process likely crashed
     // or hit a limit not covered by the SDK's result subtypes.

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -703,7 +703,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     const gen = query({ prompt: promptIterable, options });
 
     let output = '';
-    let success = true;
+    let success = false;
     let errorMessage: string | undefined;
     let resultMetrics: TaskResult['metrics'] | undefined;
 
@@ -1077,7 +1077,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     });
 
     let output = '';
-    let success = true;
+    let success = false;
     let errorMessage: string | undefined;
     const artifacts: TaskArtifact[] = [];
     let progress = 0;
@@ -1265,6 +1265,14 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     }
 
     console.log(`[claude-sdk] Task ${task.id} for-await loop exited: ${receivedResult ? 'received result message (normal)' : 'generator exhausted without result message'}`);
+
+    // If the stream ended without a result message, the process likely crashed
+    // or hit a limit not covered by the SDK's result subtypes.
+    if (!receivedResult && success) {
+      success = false;
+      errorMessage ??= 'Agent process exited without producing a result message';
+      stream.status('failed', progress, errorMessage);
+    }
 
     // Detect unauthenticated Claude Code sessions.
     // When the keychain token is missing (common on remote/HPC machines), the CLI

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -451,7 +451,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       const gen = query({ prompt: promptIterable, options });
 
       let output = '';
-      let success = true;
+      let success = false;
       let errorMessage: string | undefined;
       let newSessionId = sessionId;
       // Map tool_use_id → tool name for matching results back to uses
@@ -743,6 +743,12 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
         }
         break;
       }
+    }
+
+    // If the stream ended without a result message, treat as failure
+    if (!success && !errorMessage) {
+      errorMessage = 'Agent process exited without producing a result message';
+      stream.status('failed', 0, errorMessage);
     }
 
     return { success, output, error: errorMessage, metrics: resultMetrics };
@@ -1249,6 +1255,11 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           success = false;
           errorMessage = `Task failed: ${msg.subtype}`;
           stream.status('failed', progress, errorMessage);
+        } else {
+          // Unrecognized result subtype — treat as failure with descriptive message
+          success = false;
+          errorMessage = `Task ended with unrecognized result: ${msg.subtype}`;
+          stream.status('failed', progress, errorMessage);
         }
 
         const tokenSummary = usage ? `${usage.input_tokens ?? 0}+${usage.output_tokens ?? 0}` : 'N/A';
@@ -1268,7 +1279,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
     // If the stream ended without a result message, the process likely crashed
     // or hit a limit not covered by the SDK's result subtypes.
-    if (!receivedResult && success) {
+    if (!receivedResult) {
       success = false;
       errorMessage ??= 'Agent process exited without producing a result message';
       stream.status('failed', progress, errorMessage);

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -454,6 +454,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       let success = false;
       let errorMessage: string | undefined;
       let newSessionId = sessionId;
+      let receivedResult = false;
       // Map tool_use_id → tool name for matching results back to uses
       const resumeToolUseNames = new Map<string, string>();
 
@@ -499,9 +500,18 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           } else {
             success = false;
             errorMessage = `Resume failed: ${msg.subtype}`;
+            stream.status('failed', 0, errorMessage);
           }
+          receivedResult = true;
           break;
         }
+      }
+
+      // If the stream ended without a result message, treat as failure
+      if (!receivedResult) {
+        success = false;
+        errorMessage ??= 'Agent process exited without producing a result message';
+        stream.status('failed', 0, errorMessage);
       }
 
       // Preserve context after resume completes


### PR DESCRIPTION
## Summary
- `success` was initialized to `true` in all three SDK execution paths. If Claude Code hit its context/usage limit and exited without a recognized result subtype, the task was reported as `completed` → auto-verified → downstream tasks unblocked and all failed.
- Default `success` to `false`; only set `true` on explicit `msg.subtype === 'success'`
- Add `!receivedResult` guard: if the stream ends without a result message, explicitly fail

## Test plan
- [x] `npm run build` passes
- [ ] Trigger a Claude Code usage limit during execution — task should report `failed`, not `completed`
- [ ] Verify downstream tasks remain blocked when upstream fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)