### PR TITLE
fix(claude-sdk): re-apply systemPrompt on session resume

### DIFF
--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -1225,6 +1225,10 @@ export class TaskExecutor {
             taskWithWorkspace.resumeSessionId!,
             stream,
             abortController.signal,
+            {
+              systemPrompt: taskWithWorkspace.systemPrompt,
+              taskType: taskWithWorkspace.type,
+            },
           );
           if (resumeResult.success) {
             result = {

--- a/src/providers/base-adapter.ts
+++ b/src/providers/base-adapter.ts
@@ -4,7 +4,7 @@
 
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
-import type { Task, TaskResult, TaskStatus, ExecutionSummary } from '../types.js';
+import type { Task, TaskResult, TaskStatus, ExecutionSummary, TaskDispatchType } from '../types.js';
 
 /**
  * A task that has been normalized by the executor — workingDirectory is always
@@ -85,6 +85,12 @@ export interface ProviderAdapter {
   /**
    * Resume a completed session for post-completion follow-up.
    * Optional — only adapters that support session persistence implement this.
+   *
+   * `options.systemPrompt` re-applies the caller's system prompt so directives
+   * like plan-mode's "use astro-cli only" survive taskType transitions across
+   * turns (the resumed session otherwise replays the original prompt baked in
+   * at first execution). Adapters that don't support system-prompt override on
+   * resume may ignore it.
    */
   resumeTask?(
     taskId: string,
@@ -93,6 +99,7 @@ export interface ProviderAdapter {
     sessionId: string,
     stream: TaskOutputStream,
     signal: AbortSignal,
+    options?: { systemPrompt?: string; taskType?: TaskDispatchType },
   ): Promise<{ success: boolean; output: string; error?: string }>;
 
   /**

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -348,6 +348,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     sessionId: string,
     stream: TaskOutputStream,
     signal: AbortSignal,
+    resumeOptions?: { systemPrompt?: string; taskType?: string },
   ): Promise<{ success: boolean; output: string; error?: string }> {
     const abortController = new AbortController();
     const abortHandler = () => abortController.abort();
@@ -381,6 +382,16 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
       // Resume the previous session
       (options as Record<string, unknown>).resume = sessionId;
+
+      // Re-apply caller's system prompt so directives survive taskType
+      // transitions (e.g. chat → plan). Without this, the resumed session
+      // replays the original system prompt baked in at first execution and
+      // plan-mode instructions like "use astro-cli only, don't execute" are
+      // lost — leading to auto-execution on follow-up turns.
+      if (resumeOptions?.systemPrompt) {
+        (options as Record<string, unknown>).systemPrompt = resumeOptions.systemPrompt;
+        console.log(`[claude-sdk] Resume ${taskId.slice(0, 8)}: applied systemPrompt (${resumeOptions.systemPrompt.length} chars, taskType=${resumeOptions.taskType ?? 'unspecified'})`);
+      }
 
       // Load MCP servers from config if available
       const agentConfig = config.getConfig();


### PR DESCRIPTION
## Summary

When a Claude chat session is resumed via `resumeSessionId`, the SDK replays the original system prompt that was baked in at first execution. That means directives tied to the *current* `taskType` — most notably plan-mode's **"use astro-cli only, do not edit files, do not auto-execute"** — never make it back into the resumed session. Users who chat for a few turns (taskType=`chat`) and then switch to plan mode on turn N see the agent skip astro-cli and sometimes auto-execute tasks.

This PR plumbs `systemPrompt` (and `taskType`, for logging) from the task executor into the Claude SDK adapter's resume path and re-applies them alongside `resume`, so the caller's freshly-built prompt — reflecting the current taskType — takes effect on every turn.

### What changed

- **`base-adapter.ts`** — extends `ProviderAdapter.resumeTask` with an optional `{ systemPrompt, taskType }` options bag. Optional, so other adapters satisfy the interface unchanged.
- **`claude-sdk-adapter.ts`** — applies `resumeOptions.systemPrompt` to the SDK `options` object on the resume path, right next to `options.resume = sessionId`.
- **`task-executor.ts`** — threads `task.systemPrompt` and `task.type` into `adapter.resumeTask()` on the primary `/project-chat` resume call.

Other adapters (openclaw, opencode, codex, pi) keep their narrower signatures and ignore the new parameter for now — TS structural typing accepts the narrower method against an interface with an optional trailing param.

The `steerTask → resumeCompletedSession` path (post-completion follow-up steering) is intentionally untouched; it's a separate flow that doesn't carry `systemPrompt` today and isn't used by `/project-chat`.

---

## Architecture

```mermaid
%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#e8ecf3', 'primaryTextColor': '#2a2a2a', 'primaryBorderColor': '#9aa4b2', 'lineColor': '#6b7280', 'fontFamily': 'ui-sans-serif, system-ui', 'fontSize': '13px'}}}%%
sequenceDiagram
    autonumber
    participant FE as Frontend<br/>(project-chat)
    participant Srv as Astro server<br/>(routes/agent.ts)
    participant Exec as TaskExecutor
    participant Adp as ClaudeSdkAdapter
    participant SDK as Claude Agent SDK

    Note over FE,SDK: Turn 1 — taskType=chat
    FE->>Srv: POST /project-chat (taskType=chat)
    Srv->>Exec: dispatch(task { systemPrompt: CHAT, type: chat })
    Exec->>Adp: execute(task)
    Adp->>SDK: query({ options: { systemPrompt: CHAT } })
    SDK-->>Adp: session_id = S1

    Note over FE,SDK: Turn N — taskType=plan (resume S1)
    FE->>Srv: POST /project-chat (taskType=plan, resumeSessionId=S1)
    Srv->>Exec: dispatch(task { systemPrompt: PLAN, type: plan, resumeSessionId: S1 })
    Exec->>Adp: resumeTask(..., S1, { systemPrompt: PLAN, taskType: plan })
    Note right of Adp: BEFORE: only `resume: S1` → SDK replays CHAT prompt<br/>AFTER: `resume: S1` + `systemPrompt: PLAN` → plan directives active
    Adp->>SDK: query({ options: { resume: S1, systemPrompt: PLAN } })
    SDK-->>Adp: plan-mode behavior<br/>(uses astro-cli, no auto-exec)
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#e8ecf3', 'primaryTextColor': '#2a2a2a', 'primaryBorderColor': '#9aa4b2', 'lineColor': '#6b7280', 'fontFamily': 'ui-sans-serif, system-ui', 'fontSize': '13px'}}}%%
flowchart LR
    classDef changed fill:#fef3c7,stroke:#b45309,color:#2a2a2a
    classDef unchanged fill:#e8ecf3,stroke:#9aa4b2,color:#2a2a2a

    A[task.systemPrompt<br/>task.type]:::unchanged --> B[task-executor.ts<br/>adapter.resumeTask call]:::changed
    B --> C[base-adapter.ts<br/>ProviderAdapter.resumeTask]:::changed
    C --> D[claude-sdk-adapter.ts<br/>resumeTask impl]:::changed
    D --> E[SDK query options<br/>resume + systemPrompt]:::unchanged
```

---

## Test Plan

- [x] `npm run build` — passes (TypeScript clean, no signature drift in other adapters)
- [ ] Manual: chat for 3+ turns (taskType=chat), switch to plan mode, confirm the agent uses `astro-cli` and does not auto-execute
- [ ] Manual: repeat after SDK auto-compact fires mid-session — plan directives should still apply on the turn after compaction
- [ ] Log check: confirm `[claude-sdk] Resume <id>: applied systemPrompt (N chars, taskType=plan)` appears when resume + systemPrompt is exercised
- [ ] Regression: multi-turn chat without taskType switch still works (systemPrompt is same string, just re-applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
