### PR TITLE
Release: merge dev → main (v0.6.0)

### DIFF
--- a/src/lib/__tests__/additional-folders.test.ts
+++ b/src/lib/__tests__/additional-folders.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for additional-folders.ts helpers. We focus on:
+ *   - isPathUnderReferenceMount path-prefix semantics (no accidental /foo/bar
+ *     matching /foo/barbaz).
+ *   - setupAdditionalFolders happy-path for reference mode (filesystem-only,
+ *     no git commands).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  isPathUnderReferenceMount,
+  setupAdditionalFolders,
+} from '../additional-folders.js';
+
+describe('isPathUnderReferenceMount', () => {
+  it('returns false for empty mount list', () => {
+    expect(isPathUnderReferenceMount('/any/path', [])).toBe(false);
+  });
+
+  it('returns true for exact match', () => {
+    expect(isPathUnderReferenceMount('/home/u/ref', ['/home/u/ref'])).toBe(true);
+  });
+
+  it('returns true for path nested inside a mount', () => {
+    expect(isPathUnderReferenceMount('/home/u/ref/sub/file.ts', ['/home/u/ref'])).toBe(true);
+  });
+
+  it('does not match a sibling with a shared prefix', () => {
+    // /home/u/ref must not match /home/u/refactor
+    expect(isPathUnderReferenceMount('/home/u/refactor/file.ts', ['/home/u/ref'])).toBe(false);
+  });
+
+  it('returns false for an unrelated path', () => {
+    expect(isPathUnderReferenceMount('/var/tmp/x', ['/home/u/ref'])).toBe(false);
+  });
+
+  it('handles trailing slashes on mount input', () => {
+    expect(isPathUnderReferenceMount('/home/u/ref/a.ts', ['/home/u/ref/'])).toBe(true);
+  });
+});
+
+describe('setupAdditionalFolders (reference mode)', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'astro-extra-test-'));
+  });
+
+  it('returns an empty result when folders is undefined', async () => {
+    const result = await setupAdditionalFolders(undefined);
+    expect(result.mounts).toEqual([]);
+    await expect(result.cleanup()).resolves.toBeUndefined();
+  });
+
+  it('returns an empty result when folders is empty', async () => {
+    const result = await setupAdditionalFolders([]);
+    expect(result.mounts).toEqual([]);
+  });
+
+  it('mounts a reference folder with mountPath === hostPath', async () => {
+    writeFileSync(join(tmpRoot, 'README.md'), '# ref');
+    const result = await setupAdditionalFolders([
+      { machineId: 'm1', path: tmpRoot, mode: 'reference' },
+    ]);
+    expect(result.mounts).toHaveLength(1);
+    const m = result.mounts[0];
+    expect(m.mode).toBe('reference');
+    expect(m.hostPath).toBe(tmpRoot);
+    expect(m.mountPath).toBe(tmpRoot);
+  });
+
+  it('throws with a descriptive error when a reference path is missing', async () => {
+    const missing = join(tmpRoot, 'definitely-does-not-exist');
+    await expect(
+      setupAdditionalFolders([{ machineId: 'm1', path: missing, mode: 'reference' }]),
+    ).rejects.toThrow(/not found on this machine/);
+  });
+});
+
+describe('reference-folder write-denial hook (integration with isPathUnderReferenceMount)', () => {
+  // The canUseTool hook inside claude-sdk-adapter builds its deny decision on
+  // top of isPathUnderReferenceMount + extractPathsForWriteCheck. Re-exercise
+  // the contract here so a refactor to either helper doesn't silently regress
+  // the "write into reference folder is denied" rule.
+  it('denies Edit calls whose file_path is inside a reference mount', () => {
+    const refMounts = ['/mnt/ref-repo'];
+    const input = { file_path: '/mnt/ref-repo/src/index.ts' };
+    const isWrite = input.file_path && isPathUnderReferenceMount(input.file_path, refMounts);
+    expect(isWrite).toBe(true);
+  });
+
+  it('allows Edit calls outside reference mounts', () => {
+    const refMounts = ['/mnt/ref-repo'];
+    const input = { file_path: '/mnt/project/src/index.ts' };
+    const isWrite = input.file_path && isPathUnderReferenceMount(input.file_path, refMounts);
+    expect(isWrite).toBe(false);
+  });
+
+  it('denies Bash commands that touch paths under a reference mount', () => {
+    const refMounts = ['/mnt/ref-repo'];
+    const cmd = 'rm -rf /mnt/ref-repo/secrets';
+    const tokens = cmd.split(/\s+/).filter(t => t.startsWith('/'));
+    const anyDenied = tokens.some(t => isPathUnderReferenceMount(t, refMounts));
+    expect(anyDenied).toBe(true);
+  });
+});

--- a/src/lib/__tests__/additional-folders.test.ts
+++ b/src/lib/__tests__/additional-folders.test.ts
@@ -79,6 +79,16 @@ describe('setupAdditionalFolders (reference mode)', () => {
       setupAdditionalFolders([{ machineId: 'm1', path: missing, mode: 'reference' }]),
     ).rejects.toThrow(/not found on this machine/);
   });
+
+  it('error message includes the folder index and machineId for debuggability', async () => {
+    const missing = join(tmpRoot, 'nope');
+    await expect(
+      setupAdditionalFolders([
+        { machineId: 'm1', path: tmpRoot, mode: 'reference' },
+        { machineId: 'm-broken', path: missing, mode: 'reference' },
+      ]),
+    ).rejects.toThrow(/additionalFolders\[1\].*m-broken/);
+  });
 });
 
 describe('reference-folder write-denial hook (integration with isPathUnderReferenceMount)', () => {

--- a/src/lib/__tests__/reference-folder-guard.test.ts
+++ b/src/lib/__tests__/reference-folder-guard.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for reference-folder-guard.ts — the read-only enforcement helpers.
+ *
+ * These are the rules the Claude Agent SDK `canUseTool` hook relies on, so
+ * the contract here is security-adjacent: quoted paths must not sneak past
+ * the denial check, read tools must pass through, and the decision function
+ * must return `{ denied: true, message }` for in-mount writes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  tokenizeShellArgs,
+  extractPathsForWriteCheck,
+  buildReferenceFolderDenyHook,
+  WRITE_TOOLS,
+} from '../reference-folder-guard.js';
+
+describe('tokenizeShellArgs', () => {
+  it('splits unquoted args on whitespace', () => {
+    expect(tokenizeShellArgs('rm -rf /tmp/foo')).toEqual(['rm', '-rf', '/tmp/foo']);
+  });
+
+  it('keeps double-quoted paths containing spaces intact', () => {
+    expect(tokenizeShellArgs('rm "/mnt/ref folder/file"')).toEqual([
+      'rm',
+      '/mnt/ref folder/file',
+    ]);
+  });
+
+  it('keeps single-quoted paths intact', () => {
+    expect(tokenizeShellArgs("cat '/mnt/ref folder/a.txt'")).toEqual([
+      'cat',
+      '/mnt/ref folder/a.txt',
+    ]);
+  });
+
+  it('honors backslash-escaped spaces', () => {
+    expect(tokenizeShellArgs('rm /mnt/ref\\ folder/f')).toEqual([
+      'rm',
+      '/mnt/ref folder/f',
+    ]);
+  });
+
+  it('collapses runs of whitespace', () => {
+    expect(tokenizeShellArgs('ls   -la\t/tmp')).toEqual(['ls', '-la', '/tmp']);
+  });
+
+  it('returns empty array for an empty string', () => {
+    expect(tokenizeShellArgs('')).toEqual([]);
+  });
+});
+
+describe('extractPathsForWriteCheck', () => {
+  it('returns file_path for Edit', () => {
+    expect(extractPathsForWriteCheck('Edit', { file_path: '/a/b.ts' })).toEqual(['/a/b.ts']);
+  });
+
+  it('returns every edits[].file_path for MultiEdit', () => {
+    const input = {
+      file_path: '/a/main.ts',
+      edits: [{ file_path: '/a/main.ts' }, { file_path: '/a/other.ts' }],
+    };
+    const paths = extractPathsForWriteCheck('MultiEdit', input);
+    expect(paths).toContain('/a/main.ts');
+    expect(paths).toContain('/a/other.ts');
+  });
+
+  it('returns notebook_path for NotebookEdit', () => {
+    expect(extractPathsForWriteCheck('NotebookEdit', { notebook_path: '/a/x.ipynb' })).toEqual([
+      '/a/x.ipynb',
+    ]);
+  });
+
+  it('returns Bash args that look like paths, including quoted ones', () => {
+    const paths = extractPathsForWriteCheck('Bash', {
+      command: 'rm -rf "/mnt/ref folder/secret" /tmp/other',
+    });
+    expect(paths).toContain('/mnt/ref folder/secret');
+    expect(paths).toContain('/tmp/other');
+  });
+
+  it('ignores non-path Bash args', () => {
+    expect(extractPathsForWriteCheck('Bash', { command: 'echo hello' })).toEqual([]);
+  });
+
+  it('returns an empty list for unknown tool names', () => {
+    expect(extractPathsForWriteCheck('Read', { file_path: '/a/b.ts' })).toEqual([]);
+  });
+});
+
+describe('buildReferenceFolderDenyHook', () => {
+  it('returns undefined when there are no reference mounts', () => {
+    expect(buildReferenceFolderDenyHook([])).toBeUndefined();
+  });
+
+  it('denies Edit into a reference mount with a human-readable message', () => {
+    const hook = buildReferenceFolderDenyHook(['/mnt/ref'])!;
+    const result = hook('Edit', { file_path: '/mnt/ref/src/index.ts' });
+    expect(result.denied).toBe(true);
+    expect(result.message).toMatch(/reference folder/);
+    expect(result.message).toMatch(/\/mnt\/ref\/src\/index\.ts/);
+  });
+
+  it('allows Edit outside reference mounts', () => {
+    const hook = buildReferenceFolderDenyHook(['/mnt/ref'])!;
+    expect(hook('Edit', { file_path: '/project/src/index.ts' }).denied).toBe(false);
+  });
+
+  it('denies Bash commands that touch a quoted path inside a reference mount', () => {
+    const hook = buildReferenceFolderDenyHook(['/mnt/ref folder'])!;
+    const result = hook('Bash', { command: 'rm "/mnt/ref folder/secret"' });
+    expect(result.denied).toBe(true);
+    expect(result.message).toMatch(/\/mnt\/ref folder\/secret/);
+  });
+
+  it('allows Bash commands whose paths are outside reference mounts', () => {
+    const hook = buildReferenceFolderDenyHook(['/mnt/ref'])!;
+    expect(hook('Bash', { command: 'ls /project' }).denied).toBe(false);
+  });
+
+  it('allows read tools (Read, Grep, Glob) even when targeting a reference mount', () => {
+    const hook = buildReferenceFolderDenyHook(['/mnt/ref'])!;
+    expect(hook('Read', { file_path: '/mnt/ref/a.ts' }).denied).toBe(false);
+    expect(hook('Grep', { path: '/mnt/ref' }).denied).toBe(false);
+    expect(hook('Glob', { path: '/mnt/ref' }).denied).toBe(false);
+  });
+
+  it('denies MultiEdit if any of the edits touches a reference mount', () => {
+    const hook = buildReferenceFolderDenyHook(['/mnt/ref'])!;
+    const result = hook('MultiEdit', {
+      edits: [{ file_path: '/project/ok.ts' }, { file_path: '/mnt/ref/blocked.ts' }],
+    });
+    expect(result.denied).toBe(true);
+  });
+});
+
+describe('WRITE_TOOLS set sanity', () => {
+  it('contains the four filesystem-mutating SDK tools', () => {
+    expect(WRITE_TOOLS.has('Edit')).toBe(true);
+    expect(WRITE_TOOLS.has('Write')).toBe(true);
+    expect(WRITE_TOOLS.has('NotebookEdit')).toBe(true);
+    expect(WRITE_TOOLS.has('MultiEdit')).toBe(true);
+    expect(WRITE_TOOLS.has('Read')).toBe(false);
+  });
+});

--- a/src/lib/additional-folders.ts
+++ b/src/lib/additional-folders.ts
@@ -155,65 +155,18 @@ export async function setupAdditionalFolders(
   const mounts: AdditionalFolderMount[] = [];
   const cleanups: Array<() => Promise<void>> = [];
 
-  for (const folder of folders) {
-    if (!folder?.path) {
-      throw new Error('Additional folder entry missing path.');
+  for (let i = 0; i < folders.length; i++) {
+    const folder = folders[i];
+    const entryLabel = `additionalFolders[${i}] (machineId=${folder?.machineId ?? '<unknown>'})`;
+    try {
+      await setupOneFolder(folder, mounts, cleanups, logger);
+    } catch (err) {
+      // Wrap every per-entry error with the label so callers can pinpoint
+      // which entry in a multi-folder payload failed without losing the
+      // original message.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`${entryLabel}: ${msg}`);
     }
-    const hostPath = isAbsolute(folder.path) ? folder.path : resolve(folder.path);
-
-    if (folder.mode === 'reference') {
-      assertDirectoryExists('reference', hostPath);
-      mounts.push({ hostPath, mountPath: hostPath, mode: 'reference' });
-      logger?.operational?.(
-        `Mounted reference folder (read-only): ${hostPath}`,
-        'astro',
-      );
-      continue;
-    }
-
-    if (folder.mode === 'working') {
-      assertDirectoryExists('working', hostPath);
-      const isRepo = await isGitWorkTree(hostPath);
-      if (!isRepo) {
-        throw new Error(
-          `Additional working folder is not inside a git repository: ${hostPath}. ` +
-          `Working folders require git so a secondary worktree can be created.`,
-        );
-      }
-
-      const worktreePath = siblingWorktreePath(hostPath);
-      // If a stale worktree from a prior run remains, prune it out first so
-      // `git worktree add` doesn't refuse. Best-effort.
-      if (existsSync(worktreePath)) {
-        try {
-          await execFileAsync(
-            'git',
-            ['-C', hostPath, 'worktree', 'remove', '--force', worktreePath],
-            { timeout: 30_000 },
-          );
-        } catch {
-          try {
-            await execFileAsync('git', ['-C', hostPath, 'worktree', 'prune'], { timeout: 15_000 });
-          } catch {
-            // ignore
-          }
-        }
-      }
-
-      logger?.operational?.(
-        `Creating worktree for additional folder: ${hostPath} -> ${worktreePath}`,
-        'git',
-      );
-      await addDetachedWorktree(hostPath, worktreePath);
-      mounts.push({ hostPath, mountPath: worktreePath, mode: 'working' });
-      cleanups.push(() => removeWorktree(hostPath, worktreePath));
-      continue;
-    }
-
-    throw new Error(
-      `Unknown additional folder mode: ${String((folder as { mode?: unknown }).mode)} ` +
-      `for path ${hostPath}. Expected 'working' or 'reference'.`,
-    );
   }
 
   let cleanedUp = false;
@@ -231,6 +184,92 @@ export async function setupAdditionalFolders(
   };
 
   return { mounts, cleanup };
+}
+
+async function setupOneFolder(
+  folder: AdditionalFolderInput,
+  mounts: AdditionalFolderMount[],
+  cleanups: Array<() => Promise<void>>,
+  logger?: { operational?: (message: string, source: 'astro' | 'git' | 'delivery') => void },
+): Promise<void> {
+    if (!folder?.path) {
+      throw new Error('missing path.');
+    }
+    const hostPath = isAbsolute(folder.path) ? folder.path : resolve(folder.path);
+
+    if (folder.mode === 'reference') {
+      assertDirectoryExists('reference', hostPath);
+      mounts.push({ hostPath, mountPath: hostPath, mode: 'reference' });
+      logger?.operational?.(
+        `Mounted reference folder (read-only): ${hostPath}`,
+        'astro',
+      );
+      return;
+    }
+
+    if (folder.mode === 'working') {
+      assertDirectoryExists('working', hostPath);
+      const isRepo = await isGitWorkTree(hostPath);
+      if (!isRepo) {
+        throw new Error(
+          `working folder is not inside a git repository: ${hostPath}. ` +
+          `Working folders require git so a secondary worktree can be created.`,
+        );
+      }
+
+      const worktreePath = siblingWorktreePath(hostPath);
+      // If a stale worktree from a prior run remains, prune it out first so
+      // `git worktree add` doesn't refuse. Tight timeouts: don't let a slow
+      // or hung filesystem stall the whole task queue — if quick cleanup
+      // fails, addDetachedWorktree below will surface a clear error.
+      if (existsSync(worktreePath)) {
+        logger?.operational?.(
+          `Removing stale worktree for additional folder: ${worktreePath}`,
+          'git',
+        );
+        try {
+          await execFileAsync(
+            'git',
+            ['-C', hostPath, 'worktree', 'remove', '--force', worktreePath],
+            { timeout: 5_000 },
+          );
+        } catch {
+          try {
+            await execFileAsync('git', ['-C', hostPath, 'worktree', 'prune'], { timeout: 2_000 });
+          } catch {
+            // ignore — `git worktree add` below will error if state is still bad.
+          }
+        }
+      }
+
+      logger?.operational?.(
+        `Creating worktree for additional folder: ${hostPath} -> ${worktreePath}`,
+        'git',
+      );
+      try {
+        await addDetachedWorktree(hostPath, worktreePath);
+      } catch (addErr) {
+        // Leave the repo in a consistent state: prune any half-created
+        // worktree metadata so the next attempt isn't blocked by stale refs.
+        try {
+          await execFileAsync('git', ['-C', hostPath, 'worktree', 'prune'], { timeout: 2_000 });
+        } catch {
+          // ignore — the original add error is more useful to surface.
+        }
+        const msg = addErr instanceof Error ? addErr.message : String(addErr);
+        throw new Error(
+          `failed to create worktree at ${worktreePath}: ${msg}`,
+        );
+      }
+      mounts.push({ hostPath, mountPath: worktreePath, mode: 'working' });
+      cleanups.push(() => removeWorktree(hostPath, worktreePath));
+      return;
+    }
+
+    throw new Error(
+      `unknown mode ${String((folder as { mode?: unknown }).mode)} ` +
+      `for path ${hostPath}. Expected 'working' or 'reference'.`,
+    );
 }
 
 /**

--- a/src/lib/additional-folders.ts
+++ b/src/lib/additional-folders.ts
@@ -218,6 +218,17 @@ async function setupOneFolder(
       }
 
       const worktreePath = siblingWorktreePath(hostPath);
+      // Concurrency note: two tasks dispatched simultaneously with the same
+      // `hostPath` will compute the same `worktreePath`. We do NOT hold a
+      // BranchLockManager lock around the stale-cleanup + add sequence
+      // because the outcome under race is acceptable:
+      //   • First task wins `worktree add` and proceeds.
+      //   • Second task sees the sibling path exists, tries to remove it
+      //     (fails because it's in use), tries `worktree add`, fails fast
+      //     with a clear error via the catch below.
+      // The user sees an explicit "failed to create worktree at …" and can
+      // retry once the first task finishes. Silent fallback would be worse.
+      //
       // If a stale worktree from a prior run remains, prune it out first so
       // `git worktree add` doesn't refuse. Tight timeouts: don't let a slow
       // or hung filesystem stall the whole task queue — if quick cleanup
@@ -284,7 +295,8 @@ export function isPathUnderReferenceMount(
   if (!targetPath || referenceMountPaths.length === 0) return false;
   let abs: string;
   try {
-    abs = isAbsolute(targetPath) ? resolve(targetPath) : resolve(targetPath);
+    // resolve() is idempotent on absolute paths, so one call covers both cases.
+    abs = resolve(targetPath);
   } catch {
     return false;
   }

--- a/src/lib/additional-folders.ts
+++ b/src/lib/additional-folders.ts
@@ -1,0 +1,260 @@
+/**
+ * Additional folder mounting for multi-folder sessions.
+ *
+ * When a dispatch payload carries `additionalFolders`, the agent-runner
+ * mounts each one into the agent session:
+ *
+ * - `working` folders: a git worktree is created at a sibling path on the
+ *   folder's current HEAD (no new branch, no branch checkout on the host
+ *   folder). The worktree path is what the agent operates on so the host
+ *   folder is never mutated.
+ *
+ * - `reference` folders: the host path is mounted directly. Write-access
+ *   is enforced by the provider adapter's permission hook — this module
+ *   just verifies the path exists and passes it through.
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFileCb);
+
+export type AdditionalFolderMode = 'working' | 'reference';
+
+export interface AdditionalFolderInput {
+  machineId: string;
+  path: string;
+  mode: AdditionalFolderMode;
+}
+
+export interface AdditionalFolderMount {
+  hostPath: string;
+  mountPath: string;
+  mode: AdditionalFolderMode;
+}
+
+export interface SetupAdditionalFoldersResult {
+  mounts: AdditionalFolderMount[];
+  cleanup: () => Promise<void>;
+}
+
+const WORKTREE_PREFIX = '.astro-extra-';
+
+/** Short stable hash of an absolute path — used to keep sibling worktree names unique. */
+function pathHash(absPath: string): string {
+  return createHash('sha1').update(absPath).digest('hex').slice(0, 8);
+}
+
+function siblingWorktreePath(hostPath: string): string {
+  const parent = dirname(hostPath) || '.';
+  const base = basename(hostPath) || 'repo';
+  return join(parent, `${WORKTREE_PREFIX}${base}-${pathHash(hostPath)}`);
+}
+
+/**
+ * Verify that a path exists and is a directory. Throws with a clear,
+ * emoji-free error (per agent-runner CLAUDE.md safety-warning rules) if not.
+ */
+function assertDirectoryExists(label: string, p: string): void {
+  if (!existsSync(p)) {
+    throw new Error(
+      `Additional ${label} folder not found on this machine: ${p}. ` +
+      `The path was included in the dispatch payload but does not exist here.`,
+    );
+  }
+  const s = statSync(p);
+  if (!s.isDirectory()) {
+    throw new Error(
+      `Additional ${label} folder is not a directory: ${p}.`,
+    );
+  }
+}
+
+/**
+ * Returns true if the directory is inside a git work tree.
+ * Used to decide whether a working-mode folder can get a secondary worktree.
+ */
+async function isGitWorkTree(dir: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', dir, 'rev-parse', '--is-inside-work-tree'],
+      { timeout: 5_000 },
+    );
+    return stdout.trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create a git worktree at `worktreePath` pointing at the current HEAD of
+ * `sourceRepo` (no new branch — `--detach` keeps the worktree on HEAD without
+ * fighting with the source folder's checked-out branch).
+ */
+async function addDetachedWorktree(sourceRepo: string, worktreePath: string): Promise<void> {
+  // `git worktree add --detach <path> HEAD` creates a worktree at HEAD
+  // without requiring a new branch and without moving the source folder's
+  // branch, which is exactly what we want: leave the user's folder alone.
+  await execFileAsync(
+    'git',
+    ['-C', sourceRepo, 'worktree', 'add', '--detach', worktreePath, 'HEAD'],
+    { timeout: 60_000 },
+  );
+}
+
+/** Best-effort worktree removal. Logs on failure; never throws. */
+async function removeWorktree(sourceRepo: string, worktreePath: string): Promise<void> {
+  try {
+    await execFileAsync(
+      'git',
+      ['-C', sourceRepo, 'worktree', 'remove', '--force', worktreePath],
+      { timeout: 30_000 },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[additional-folders] worktree remove failed for ${worktreePath}: ${msg}. ` +
+      `Proceeding (best-effort cleanup).`,
+    );
+    // Fallback: prune stale worktree metadata so the repo isn't left confused.
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', sourceRepo, 'worktree', 'prune'],
+        { timeout: 15_000 },
+      );
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Set up all additional folders for a task.
+ *
+ * For each folder:
+ *   - reference: verify the path exists; mountPath = hostPath.
+ *   - working: verify it's a git repo; create a detached sibling worktree
+ *     at `<parent>/.astro-extra-<basename>-<sha8>`; mountPath = worktree path.
+ *
+ * Returns the resolved mounts plus a cleanup function that best-effort removes
+ * any worktrees that were created. The cleanup is safe to call multiple times.
+ */
+export async function setupAdditionalFolders(
+  folders: AdditionalFolderInput[] | undefined,
+  logger?: { operational?: (message: string, source: 'astro' | 'git' | 'delivery') => void },
+): Promise<SetupAdditionalFoldersResult> {
+  if (!folders || folders.length === 0) {
+    return { mounts: [], cleanup: async () => {} };
+  }
+
+  const mounts: AdditionalFolderMount[] = [];
+  const cleanups: Array<() => Promise<void>> = [];
+
+  for (const folder of folders) {
+    if (!folder?.path) {
+      throw new Error('Additional folder entry missing path.');
+    }
+    const hostPath = isAbsolute(folder.path) ? folder.path : resolve(folder.path);
+
+    if (folder.mode === 'reference') {
+      assertDirectoryExists('reference', hostPath);
+      mounts.push({ hostPath, mountPath: hostPath, mode: 'reference' });
+      logger?.operational?.(
+        `Mounted reference folder (read-only): ${hostPath}`,
+        'astro',
+      );
+      continue;
+    }
+
+    if (folder.mode === 'working') {
+      assertDirectoryExists('working', hostPath);
+      const isRepo = await isGitWorkTree(hostPath);
+      if (!isRepo) {
+        throw new Error(
+          `Additional working folder is not inside a git repository: ${hostPath}. ` +
+          `Working folders require git so a secondary worktree can be created.`,
+        );
+      }
+
+      const worktreePath = siblingWorktreePath(hostPath);
+      // If a stale worktree from a prior run remains, prune it out first so
+      // `git worktree add` doesn't refuse. Best-effort.
+      if (existsSync(worktreePath)) {
+        try {
+          await execFileAsync(
+            'git',
+            ['-C', hostPath, 'worktree', 'remove', '--force', worktreePath],
+            { timeout: 30_000 },
+          );
+        } catch {
+          try {
+            await execFileAsync('git', ['-C', hostPath, 'worktree', 'prune'], { timeout: 15_000 });
+          } catch {
+            // ignore
+          }
+        }
+      }
+
+      logger?.operational?.(
+        `Creating worktree for additional folder: ${hostPath} -> ${worktreePath}`,
+        'git',
+      );
+      await addDetachedWorktree(hostPath, worktreePath);
+      mounts.push({ hostPath, mountPath: worktreePath, mode: 'working' });
+      cleanups.push(() => removeWorktree(hostPath, worktreePath));
+      continue;
+    }
+
+    throw new Error(
+      `Unknown additional folder mode: ${String((folder as { mode?: unknown }).mode)} ` +
+      `for path ${hostPath}. Expected 'working' or 'reference'.`,
+    );
+  }
+
+  let cleanedUp = false;
+  const cleanup = async (): Promise<void> => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    for (const fn of cleanups) {
+      try {
+        await fn();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[additional-folders] cleanup step failed: ${msg}`);
+      }
+    }
+  };
+
+  return { mounts, cleanup };
+}
+
+/**
+ * Returns true if `targetPath` resolves under any `referenceMount.mountPath`.
+ * Uses string-prefix matching on resolved absolute paths with a trailing
+ * separator guard so /foo/bar does not match /foo/barbaz.
+ */
+export function isPathUnderReferenceMount(
+  targetPath: string,
+  referenceMountPaths: readonly string[],
+): boolean {
+  if (!targetPath || referenceMountPaths.length === 0) return false;
+  let abs: string;
+  try {
+    abs = isAbsolute(targetPath) ? resolve(targetPath) : resolve(targetPath);
+  } catch {
+    return false;
+  }
+  for (const raw of referenceMountPaths) {
+    if (!raw) continue;
+    const root = resolve(raw);
+    if (abs === root) return true;
+    const rootWithSep = root.endsWith('/') ? root : root + '/';
+    if (abs.startsWith(rootWithSep)) return true;
+  }
+  return false;
+}

--- a/src/lib/reference-folder-guard.ts
+++ b/src/lib/reference-folder-guard.ts
@@ -1,0 +1,150 @@
+/**
+ * Reference-folder write-guard helpers.
+ *
+ * When a task session mounts one or more `reference` additional folders, the
+ * agent-runner enforces read-only access at the Claude Agent SDK permission
+ * layer via `canUseTool`. This module contains the small, pure helpers that
+ * back that enforcement so they're easy to unit-test without pulling in the
+ * SDK:
+ *
+ *   • `tokenizeShellArgs` — quote/backslash-aware shell tokenizer
+ *   • `extractPathsForWriteCheck` — pulls candidate paths out of a tool input
+ *   • `buildReferenceFolderDenyHook` — returns a decision function usable
+ *     inside a `canUseTool` callback
+ *
+ * The SDK surfaces a deny decision to the agent as a failed tool_result on
+ * its own, so the hook only has to return `{ denied: true, message }`.
+ */
+
+import { isPathUnderReferenceMount } from './additional-folders.js';
+
+/** Tools that can mutate filesystem state and therefore must be guarded. */
+export const WRITE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
+
+/**
+ * Tokenize a shell command into argument-like chunks while respecting quoted
+ * strings and backslash-escaped whitespace. Not a full POSIX parser — just
+ * enough to keep quoted paths like `rm "/mnt/ref folder/file"` intact so the
+ * reference-mount guard can't be bypassed by wrapping a path in quotes.
+ *
+ * Supported:
+ *   • Single quotes: 'path with space' → literal contents
+ *   • Double quotes: "path with space" → literal contents (no escape expansion)
+ *   • Backslash-escaped whitespace: foo\ bar → "foo bar"
+ *   • Unquoted runs split on whitespace
+ *
+ * Unsupported (acceptable for a defense-in-depth check): variable expansion,
+ * command substitution, `$'...'` ANSI-C quoting.
+ */
+export function tokenizeShellArgs(cmd: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let quote: '"' | "'" | null = null;
+  let hasContent = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i];
+    if (quote) {
+      if (c === quote) { quote = null; continue; }
+      buf += c;
+      hasContent = true;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; hasContent = true; continue; }
+    if (c === '\\' && i + 1 < cmd.length) {
+      // Backslash-escaped next char (commonly a space): include literally.
+      buf += cmd[i + 1];
+      hasContent = true;
+      i++;
+      continue;
+    }
+    if (c === ' ' || c === '\t' || c === '\n') {
+      if (hasContent) { out.push(buf); buf = ''; hasContent = false; }
+      continue;
+    }
+    buf += c;
+    hasContent = true;
+  }
+  if (hasContent) out.push(buf);
+  return out;
+}
+
+/**
+ * Extract candidate filesystem paths from a tool input. Returns every path
+ * that should be checked against the reference-mount guard. Covers the
+ * built-in Edit/Write/NotebookEdit/MultiEdit inputs and best-effort Bash
+ * parsing (quote-aware tokenizer).
+ */
+export function extractPathsForWriteCheck(
+  toolName: string,
+  input: Record<string, unknown>,
+): string[] {
+  const paths: string[] = [];
+  const pushIfString = (v: unknown): void => {
+    if (typeof v === 'string' && v.length > 0) paths.push(v);
+  };
+
+  if (
+    toolName === 'Edit' ||
+    toolName === 'Write' ||
+    toolName === 'NotebookEdit' ||
+    toolName === 'MultiEdit'
+  ) {
+    pushIfString((input as { file_path?: unknown }).file_path);
+    pushIfString((input as { notebook_path?: unknown }).notebook_path);
+    pushIfString((input as { path?: unknown }).path);
+    const edits = (input as { edits?: unknown }).edits;
+    if (Array.isArray(edits)) {
+      for (const e of edits) {
+        if (e && typeof e === 'object') {
+          pushIfString((e as { file_path?: unknown }).file_path);
+        }
+      }
+    }
+    return paths;
+  }
+
+  if (toolName === 'Bash' || toolName === 'bash') {
+    const cmd = (input as { command?: unknown }).command;
+    if (typeof cmd === 'string') {
+      for (const t of tokenizeShellArgs(cmd)) {
+        if (t.startsWith('/') || t.startsWith('./') || t.startsWith('../') || t.startsWith('~/')) {
+          paths.push(t);
+        }
+      }
+    }
+  }
+  return paths;
+}
+
+export interface ReferenceFolderDenyResult {
+  denied: boolean;
+  message?: string;
+}
+
+/**
+ * Build a decision function suitable for use inside the Claude Agent SDK's
+ * `canUseTool` callback. Returns `undefined` when there are no reference
+ * mounts so the caller can skip installing the wrapper entirely.
+ */
+export function buildReferenceFolderDenyHook(
+  referenceMountPaths: readonly string[],
+): ((toolName: string, input: Record<string, unknown>) => ReferenceFolderDenyResult) | undefined {
+  if (referenceMountPaths.length === 0) return undefined;
+
+  return (toolName: string, input: Record<string, unknown>): ReferenceFolderDenyResult => {
+    if (!WRITE_TOOLS.has(toolName) && toolName !== 'Bash' && toolName !== 'bash') {
+      return { denied: false };
+    }
+
+    const candidates = extractPathsForWriteCheck(toolName, input);
+    for (const p of candidates) {
+      if (isPathUnderReferenceMount(p, referenceMountPaths)) {
+        const message =
+          `Denied: ${toolName} targets a read-only reference folder (${p}). ` +
+          `Reference folders are mounted read-only and cannot be modified.`;
+        return { denied: true, message };
+      }
+    }
+    return { denied: false };
+  };
+}

--- a/src/lib/reference-folder-guard.ts
+++ b/src/lib/reference-folder-guard.ts
@@ -106,6 +106,15 @@ export function extractPathsForWriteCheck(
   if (toolName === 'Bash' || toolName === 'bash') {
     const cmd = (input as { command?: unknown }).command;
     if (typeof cmd === 'string') {
+      // Defense-in-depth heuristic: flag any token that looks like a POSIX
+      // path (starts with /, ./, ../, ~/). We intentionally do not expand
+      // environment variables ($HOME/file), command substitutions ($(pwd)/x),
+      // glob patterns (/tmp/*.txt), or handle Windows-style drive paths
+      // (C:\...). A determined attacker with shell-metacharacter knowledge
+      // could still craft a path that slips past — the SDK sandbox and the
+      // additional-directories allowlist remain the authoritative guards.
+      // Do not weaken this check without preserving the quote-aware tokenizer
+      // above: quoted paths with spaces MUST be treated as a single token.
       for (const t of tokenizeShellArgs(cmd)) {
         if (t.startsWith('/') || t.startsWith('./') || t.startsWith('../') || t.startsWith('~/')) {
           paths.push(t);

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -267,8 +267,8 @@ export class TaskExecutor {
     storedAt: number;
   }> = new Map();
 
-  /** TTL for completed task metadata (10 minutes, matches adapter session TTL) */
-  private static readonly COMPLETED_TASK_META_TTL_MS = 10 * 60 * 1000;
+  /** TTL for completed task metadata (30 minutes, allows follow-up execution to recreate worktrees) */
+  private static readonly COMPLETED_TASK_META_TTL_MS = 30 * 60 * 1000;
 
   constructor(options: TaskExecutorOptions) {
     this.wsClient = options.wsClient;
@@ -326,11 +326,11 @@ export class TaskExecutor {
     this.claimedTasks.add(task.id);
     try {
 
-    // Only execution tasks need workingDirectory resolution, safety checks,
+    // Execution and follow-up tasks need workingDirectory resolution, safety checks,
     // git diff, and summary generation. All other types (plan/chat/summarize/
     // playground) skip this overhead but still get full tool access when they
     // have a working directory.
-    const isExecutionTask = !task.type || task.type === 'execution';
+    const isExecutionTask = !task.type || task.type === 'execution' || task.type === 'follow-up';
 
     // Non-execution tasks can run without a working directory.
     // For execution tasks, resolve the directory or auto-provision one.
@@ -1163,9 +1163,9 @@ export class TaskExecutor {
       );
     }, TASK_HEARTBEAT_INTERVAL_MS);
 
-    // Only execution tasks get git diff, delivery, and summary — all other types (chat, plan, playground, summarize) skip them.
+    // Execution and follow-up tasks get git diff, delivery, and summary — all other types (chat, plan, playground, summarize) skip them.
     // These non-execution types still get full tool access when they have a working directory.
-    const isExecutionTask = !normalizedTask.type || normalizedTask.type === 'execution';
+    const isExecutionTask = !normalizedTask.type || normalizedTask.type === 'execution' || normalizedTask.type === 'follow-up';
     let prepared: Awaited<ReturnType<typeof this.prepareTaskWorkspace>>;
     try {
       prepared = !isExecutionTask && !normalizedTask.workingDirectory
@@ -1205,10 +1205,11 @@ export class TaskExecutor {
       // Notify task started
       this.wsClient.sendTaskStatus(task.id, 'running', 0, 'Starting');
 
-      // Resume existing session if resumeSessionId is provided
+      // Resume existing session if resumeSessionId is provided.
+      // Follow-up tasks are treated as execution (get delivery pipeline) but also allow session resume.
       const canResume = taskWithWorkspace.resumeSessionId
         && this.isResumableAdapter(adapter)
-        && !isExecutionTask;
+        && (!isExecutionTask || normalizedTask.type === 'follow-up');
 
       let result: Awaited<ReturnType<typeof adapter.execute>>;
       if (canResume) {

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -18,6 +18,7 @@ import { OpenClawAdapter } from '../providers/openclaw-adapter.js';
 import type { OpenClawBridge } from './openclaw-bridge.js';
 import { SlurmJobMonitor } from './slurm-job-monitor.js';
 import { createWorktree, syncDeliveryWorktree, getGitRoot } from './worktree.js';
+import { setupAdditionalFolders, type AdditionalFolderMount } from './additional-folders.js';
 import { ensureProjectWorkspace } from './workspace-root.js';
 import { BranchLockManager } from './branch-lock.js';
 import { pushAndCreatePR, mergePullRequest, getRemoteBranchSha, isGhAvailable, getRepoSlug } from './git-pr.js';
@@ -1186,6 +1187,43 @@ export class TaskExecutor {
     runningTask.task = taskWithWorkspace;
     console.log(`[executor] Task ${task.id}: workspace prepared, cwd=${prepared.workingDirectory}`);
 
+    // Set up additional folders (working worktrees + reference mounts).
+    // Failures during setup (missing path, not a git repo for working mode)
+    // must fail the task — we never silently drop a mount the user asked for.
+    let additionalFoldersCleanup: (() => Promise<void>) | undefined;
+    let additionalFolderMounts: AdditionalFolderMount[] = [];
+    if (normalizedTask.additionalFolders && normalizedTask.additionalFolders.length > 0) {
+      try {
+        const result = await setupAdditionalFolders(
+          normalizedTask.additionalFolders,
+          { operational: stream.operational },
+        );
+        additionalFolderMounts = result.mounts;
+        additionalFoldersCleanup = result.cleanup;
+        taskWithWorkspace._resolvedAdditionalFolders = additionalFolderMounts;
+        runningTask.task = taskWithWorkspace;
+        console.log(
+          `[executor] Task ${task.id}: mounted ${additionalFolderMounts.length} additional folder(s): ` +
+          additionalFolderMounts.map(m => `${m.mode}:${m.hostPath}`).join(', '),
+        );
+      } catch (extraErr) {
+        clearInterval(taskHeartbeatTimer);
+        const msg = extraErr instanceof Error ? extraErr.message : String(extraErr);
+        console.error(`[executor] Task ${task.id}: additional folder setup failed: ${msg}`);
+        stream.operational?.(`Additional folder setup failed: ${msg}`, 'astro');
+        // Run primary cleanup before rethrowing so the main worktree is released.
+        try {
+          await prepared.cleanup({ keepBranch: false });
+        } catch (cleanupErr) {
+          const cmsg = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+          console.warn(`[executor] Task ${task.id}: primary cleanup after additional-folder failure: ${cmsg}`);
+        }
+        this.runningTasks.delete(normalizedTask.id);
+        this.untrackTaskDirectory(task);
+        throw extraErr;
+      }
+    }
+
     // Execute with idle timeout + hard cap.
     // Idle timeout resets on every stream activity (text, tool, file, etc.).
     // Hard cap is a non-resettable safety limit.
@@ -1225,6 +1263,10 @@ export class TaskExecutor {
             taskWithWorkspace.resumeSessionId!,
             stream,
             abortController.signal,
+            {
+              systemPrompt: taskWithWorkspace.systemPrompt,
+              taskType: taskWithWorkspace.type,
+            },
           );
           if (resumeResult.success) {
             result = {
@@ -1692,6 +1734,19 @@ export class TaskExecutor {
     } finally {
       clearTimeout(hardCapTimeoutId);
       if (idleTimerId !== undefined) clearTimeout(idleTimerId);
+
+      // Clean up any additional-folder worktrees before the primary worktree.
+      // Best-effort: failures log but never throw — cleanup must not mask
+      // the real task result.
+      if (additionalFoldersCleanup) {
+        try {
+          await additionalFoldersCleanup();
+          console.log(`[executor] Task ${task.id}: additional folder worktrees cleaned up`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[executor] Task ${task.id}: additional folder cleanup failed: ${msg}`);
+        }
+      }
 
       // Always cleanup the local worktree directory to reclaim disk space
       // (node_modules alone is ~680MB per worktree). When keepBranch is true

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -1225,6 +1225,10 @@ export class TaskExecutor {
             taskWithWorkspace.resumeSessionId!,
             stream,
             abortController.signal,
+            {
+              systemPrompt: taskWithWorkspace.systemPrompt,
+              taskType: taskWithWorkspace.type,
+            },
           );
           if (resumeResult.success) {
             result = {

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -1211,16 +1211,29 @@ export class TaskExecutor {
         const msg = extraErr instanceof Error ? extraErr.message : String(extraErr);
         console.error(`[executor] Task ${task.id}: additional folder setup failed: ${msg}`);
         stream.operational?.(`Additional folder setup failed: ${msg}`, 'astro');
-        // Run primary cleanup before rethrowing so the main worktree is released.
+        // Run primary cleanup before reporting so the main worktree is released.
         try {
           await prepared.cleanup({ keepBranch: false });
         } catch (cleanupErr) {
           const cmsg = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
           console.warn(`[executor] Task ${task.id}: primary cleanup after additional-folder failure: ${cmsg}`);
         }
+        // Report failure to the server directly — executeTask() is invoked from
+        // several paths (submitTask, handleSafetyDecision, processQueue) and not
+        // all of them catch thrown errors. Matches the sandbox/provider-error
+        // failure pattern above. sendTaskResult + removeActiveTask are idempotent
+        // so if processQueue's outer catch also runs later, it's a no-op.
+        this.wsClient.sendTaskResult({
+          taskId: task.id,
+          status: 'failed',
+          error: `Additional folder setup failed: ${msg}`,
+          completedAt: new Date().toISOString(),
+        });
         this.runningTasks.delete(normalizedTask.id);
+        this.wsClient.removeActiveTask(task.id);
         this.untrackTaskDirectory(task);
-        throw extraErr;
+        this.processQueue();
+        return;
       }
     }
 

--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -1190,9 +1190,45 @@ export class TaskExecutor {
     // Set up additional folders (working worktrees + reference mounts).
     // Failures during setup (missing path, not a git repo for working mode)
     // must fail the task — we never silently drop a mount the user asked for.
+    //
+    // Provider-parity guard: additional folders are only honored by the
+    // claude-sdk adapter today. Other adapters (codex, openclaw, opencode,
+    // slurm) don't wire the mount paths into the CLI or enforce the
+    // reference-folder deny hook, so silently accepting the request would
+    // give the user a task that "succeeds" with none of the folders
+    // actually visible to the agent. Fail fast instead.
     let additionalFoldersCleanup: (() => Promise<void>) | undefined;
     let additionalFolderMounts: AdditionalFolderMount[] = [];
     if (normalizedTask.additionalFolders && normalizedTask.additionalFolders.length > 0) {
+      if (normalizedTask.provider !== 'claude-sdk') {
+        clearInterval(taskHeartbeatTimer);
+        const msg =
+          `Additional folders are only supported with the claude-sdk provider. ` +
+          `This task requested provider=${normalizedTask.provider}.`;
+        console.error(`[executor] Task ${task.id}: ${msg}`);
+        stream.operational?.(msg, 'astro');
+        try {
+          await prepared.cleanup({ keepBranch: false });
+        } catch (cleanupErr) {
+          const cmsg = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+          console.warn(`[executor] Task ${task.id}: primary cleanup after provider-parity failure: ${cmsg}`);
+        }
+        this.wsClient.sendTaskResult({
+          taskId: task.id,
+          status: 'failed',
+          error: msg,
+          completedAt: new Date().toISOString(),
+        });
+        // Note: normalizedTask.id and taskWithWorkspace.id are the same — the
+        // latter is a shallow spread of the former with only `workingDirectory`
+        // overridden, so runningTasks.delete(normalizedTask.id) removes the
+        // correct entry regardless of which alias we use.
+        this.runningTasks.delete(normalizedTask.id);
+        this.wsClient.removeActiveTask(task.id);
+        this.untrackTaskDirectory(task);
+        this.processQueue();
+        return;
+      }
       try {
         const result = await setupAdditionalFolders(
           normalizedTask.additionalFolders,
@@ -1204,7 +1240,9 @@ export class TaskExecutor {
         runningTask.task = taskWithWorkspace;
         console.log(
           `[executor] Task ${task.id}: mounted ${additionalFolderMounts.length} additional folder(s): ` +
-          additionalFolderMounts.map(m => `${m.mode}:${m.hostPath}`).join(', '),
+          additionalFolderMounts
+            .map(m => m.mode === 'working' ? `${m.mode}:${m.hostPath}→${m.mountPath}` : `${m.mode}:${m.hostPath}`)
+            .join(', '),
         );
       } catch (extraErr) {
         clearInterval(taskHeartbeatTimer);

--- a/src/providers/base-adapter.ts
+++ b/src/providers/base-adapter.ts
@@ -4,7 +4,7 @@
 
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
-import type { Task, TaskResult, TaskStatus, ExecutionSummary } from '../types.js';
+import type { Task, TaskResult, TaskStatus, ExecutionSummary, TaskDispatchType } from '../types.js';
 
 /**
  * A task that has been normalized by the executor — workingDirectory is always
@@ -85,6 +85,12 @@ export interface ProviderAdapter {
   /**
    * Resume a completed session for post-completion follow-up.
    * Optional — only adapters that support session persistence implement this.
+   *
+   * `options.systemPrompt` re-applies the caller's system prompt so directives
+   * like plan-mode's "use astro-cli only" survive taskType transitions across
+   * turns (the resumed session otherwise replays the original prompt baked in
+   * at first execution). Adapters that don't support system-prompt override on
+   * resume may ignore it.
    */
   resumeTask?(
     taskId: string,
@@ -93,6 +99,7 @@ export interface ProviderAdapter {
     sessionId: string,
     stream: TaskOutputStream,
     signal: AbortSignal,
+    options?: { systemPrompt?: string; taskType?: TaskDispatchType },
   ): Promise<{ success: boolean; output: string; error?: string }>;
 
   /**

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -716,6 +716,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     let success = false;
     let errorMessage: string | undefined;
     let resultMetrics: TaskResult['metrics'] | undefined;
+    let receivedResult = false;
 
     for await (const msg of gen) {
       if (msg.type === 'system' && msg.subtype === 'init') {
@@ -751,13 +752,15 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           errorMessage = `Task failed: ${msg.subtype}`;
           stream.status('failed', 0, errorMessage);
         }
+        receivedResult = true;
         break;
       }
     }
 
     // If the stream ended without a result message, treat as failure
-    if (!success && !errorMessage) {
-      errorMessage = 'Agent process exited without producing a result message';
+    if (!receivedResult) {
+      success = false;
+      errorMessage ??= 'Agent process exited without producing a result message';
       stream.status('failed', 0, errorMessage);
     }
 
@@ -1104,6 +1107,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
     let turnIndex = 0;
     let receivedResult = false;
+    let lastResultSubtype: string | undefined;
 
     for await (const msg of gen) {
       try {
@@ -1216,6 +1220,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       } else if (msg.type === 'result') {
         // Extract metrics from SDK result (available on both success and error subtypes)
         const msgAny = msg as Record<string, unknown>;
+        lastResultSubtype = msg.subtype;
         const usage = msgAny.usage as { input_tokens?: number; output_tokens?: number } | undefined;
         const totalCostUsd = (msgAny.total_cost_usd ?? msgAny.cost_usd) as number | undefined;
         const numTurns = msgAny.num_turns as number | undefined;
@@ -1266,9 +1271,10 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           errorMessage = `Task failed: ${msg.subtype}`;
           stream.status('failed', progress, errorMessage);
         } else {
-          // Unrecognized result subtype — treat as failure with descriptive message
+          // Unrecognized result subtype — treat as failure with descriptive message.
+          // Likely a Claude Code version mismatch or new SDK error subtype.
           success = false;
-          errorMessage = `Task ended with unrecognized result: ${msg.subtype}`;
+          errorMessage = `Task ended with unrecognized SDK result subtype: ${msg.subtype} — this may indicate a Claude Code version mismatch or SDK change`;
           stream.status('failed', progress, errorMessage);
         }
 
@@ -1285,7 +1291,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       }
     }
 
-    console.log(`[claude-sdk] Task ${task.id} for-await loop exited: ${receivedResult ? 'received result message (normal)' : 'generator exhausted without result message'}`);
+    console.log(`[claude-sdk] Task ${task.id} for-await loop exited: ${receivedResult ? `received result message (subtype=${lastResultSubtype ?? 'unknown'})` : 'generator exhausted without result message'}`);
 
     // If the stream ended without a result message, the process likely crashed
     // or hit a limit not covered by the SDK's result subtypes.

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -41,12 +41,96 @@ const claudeExecutablePath = resolveClaudeExecutable();
 import type { Task, TaskResult, TaskArtifact, ExecutionSummary, HpcCapability } from '../types.js';
 import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
 import { type ProviderAdapter, type NormalizedTask, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse, getAugmentedPath } from './base-adapter.js';
+import { isPathUnderReferenceMount } from '../lib/additional-folders.js';
 import { buildHpcContext, type HpcContext } from '../lib/hpc-context.js';
 import type { SlurmJobMonitor } from '../lib/slurm-job-monitor.js';
 import { config } from '../lib/config.js';
 
 /** Shell execution tools whose output may contain real sbatch submissions */
 const SHELL_TOOLS = new Set(['Bash', 'bash', 'shell', 'execute_command', 'terminal']);
+
+/**
+ * Tools that can mutate the filesystem and must be denied when their target
+ * resolves under a reference-mode additional folder.
+ */
+const WRITE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
+
+/**
+ * Extract candidate filesystem paths from a tool input. Returns every path
+ * that should be checked against the reference-mount guard. Covers the
+ * built-in Edit/Write/NotebookEdit inputs and best-effort Bash parsing.
+ */
+function extractPathsForWriteCheck(toolName: string, input: Record<string, unknown>): string[] {
+  const paths: string[] = [];
+  const pushIfString = (v: unknown): void => {
+    if (typeof v === 'string' && v.length > 0) paths.push(v);
+  };
+
+  if (toolName === 'Edit' || toolName === 'Write' || toolName === 'NotebookEdit' || toolName === 'MultiEdit') {
+    pushIfString((input as { file_path?: unknown }).file_path);
+    pushIfString((input as { notebook_path?: unknown }).notebook_path);
+    pushIfString((input as { path?: unknown }).path);
+    // MultiEdit: edits[].file_path
+    const edits = (input as { edits?: unknown }).edits;
+    if (Array.isArray(edits)) {
+      for (const e of edits) {
+        if (e && typeof e === 'object') {
+          pushIfString((e as { file_path?: unknown }).file_path);
+        }
+      }
+    }
+    return paths;
+  }
+
+  if (toolName === 'Bash' || toolName === 'bash') {
+    const cmd = (input as { command?: unknown }).command;
+    if (typeof cmd === 'string') {
+      // Best-effort: tokenize and keep anything that looks like a path
+      // argument (starts with /, ./, ../, or ~/). The reference-mount guard
+      // only fires on paths under a known reference root, so false positives
+      // on unrelated tokens are harmless.
+      const tokens = cmd.split(/\s+/);
+      for (const t of tokens) {
+        const unquoted = t.replace(/^['"]|['"]$/g, '');
+        if (unquoted.startsWith('/') || unquoted.startsWith('./') || unquoted.startsWith('../') || unquoted.startsWith('~/')) {
+          paths.push(unquoted);
+        }
+      }
+    }
+  }
+  return paths;
+}
+
+/**
+ * Build a canUseTool wrapper that denies write/edit/bash calls whose target
+ * resolves under any reference-mode additional folder. When `referenceMountPaths`
+ * is empty, returns `undefined` so callers can skip installing the wrapper.
+ */
+function buildReferenceFolderDenyHook(
+  referenceMountPaths: readonly string[],
+  stream?: { toolResult?: (toolName: string, result: unknown, success: boolean, toolUseId?: string) => void },
+): ((toolName: string, input: Record<string, unknown>, toolUseID: string) => { denied: boolean; message?: string }) | undefined {
+  if (referenceMountPaths.length === 0) return undefined;
+
+  return (toolName: string, input: Record<string, unknown>, toolUseID: string) => {
+    if (!WRITE_TOOLS.has(toolName) && toolName !== 'Bash' && toolName !== 'bash') {
+      return { denied: false };
+    }
+
+    const candidates = extractPathsForWriteCheck(toolName, input);
+    for (const p of candidates) {
+      if (isPathUnderReferenceMount(p, referenceMountPaths)) {
+        const message =
+          `Denied: ${toolName} targets a read-only reference folder (${p}). ` +
+          `Reference folders are mounted read-only and cannot be modified.`;
+        // Surface the denial to the UI as a failed tool_result, not a silent no-op.
+        stream?.toolResult?.(toolName, message, false, toolUseID);
+        return { denied: true, message };
+      }
+    }
+    return { denied: false };
+  };
+}
 
 /**
  * Determine whether to enable sandbox mode for Claude Code.
@@ -348,6 +432,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     sessionId: string,
     stream: TaskOutputStream,
     signal: AbortSignal,
+    resumeOptions?: { systemPrompt?: string; taskType?: string },
   ): Promise<{ success: boolean; output: string; error?: string }> {
     const abortController = new AbortController();
     const abortHandler = () => abortController.abort();
@@ -381,6 +466,16 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
       // Resume the previous session
       (options as Record<string, unknown>).resume = sessionId;
+
+      // Re-apply caller's system prompt so directives survive taskType
+      // transitions (e.g. chat → plan). Without this, the resumed session
+      // replays the original system prompt baked in at first execution and
+      // plan-mode instructions like "use astro-cli only, don't execute" are
+      // lost — leading to auto-execution on follow-up turns.
+      if (resumeOptions?.systemPrompt) {
+        (options as Record<string, unknown>).systemPrompt = resumeOptions.systemPrompt;
+        console.log(`[claude-sdk] Resume ${taskId.slice(0, 8)}: applied systemPrompt (${resumeOptions.systemPrompt.length} chars, taskType=${resumeOptions.taskType ?? 'unspecified'})`);
+      }
 
       // Load MCP servers from config if available
       const agentConfig = config.getConfig();
@@ -775,6 +870,17 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     // ── Standard path for all other task types (plan/chat/playground/execution) ──
     // All get full tool access; the prompt controls behavior.
 
+    // Resolve additional folder mounts set up by the task executor.
+    // Working-mode mounts point at a secondary worktree (agent-writable).
+    // Reference-mode mounts point at the host path (read-only; guarded by
+    // the canUseTool deny hook below).
+    const resolvedAdditionalFolders = task._resolvedAdditionalFolders ?? [];
+    const additionalMountPaths = resolvedAdditionalFolders.map((m) => m.mountPath);
+    const referenceMountPaths = resolvedAdditionalFolders
+      .filter((m) => m.mode === 'reference')
+      .map((m) => m.mountPath);
+    const referenceDenyHook = buildReferenceFolderDenyHook(referenceMountPaths, stream);
+
     // Build options for the query
     const options: Parameters<typeof query>[0]['options'] = {
       abortController,
@@ -786,7 +892,11 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       ...getSandboxOption(task.model),
       settingSources: ['user', 'project', 'local'], // Load CLAUDE.md from user home, project dir, and cwd
       persistSession: true, // Keep session on disk so generateSummary() can resume it
-      ...(workdir ? { cwd: workdir, additionalDirectories: [workdir] } : {}),
+      ...(workdir
+        ? { cwd: workdir, additionalDirectories: [workdir, ...additionalMountPaths] }
+        : additionalMountPaths.length > 0
+          ? { additionalDirectories: [...additionalMountPaths] }
+          : {}),
       // Use globally installed claude binary if available (avoids missing cli.js on remote machines)
       ...(claudeExecutablePath ? { pathToClaudeCodeExecutable: claudeExecutablePath } : {}),
       // Capture subprocess stderr for debugging exit code 1 crashes
@@ -810,6 +920,17 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       },
       // Intercept built-in AskUserQuestion to handle approvals (following Cyrus pattern)
       canUseTool: async (toolName: string, input: Record<string, unknown>, options: { toolUseID: string; signal: AbortSignal }) => {
+        // Deny write/edit/bash calls that target read-only reference folders.
+        // This runs first so the denial is surfaced before any other handling.
+        if (referenceDenyHook) {
+          const check = referenceDenyHook(toolName, input, options.toolUseID);
+          if (check.denied) {
+            return {
+              behavior: 'deny' as const,
+              message: check.message ?? 'Write blocked: target is inside a read-only reference folder.',
+            };
+          }
+        }
         if (toolName === 'AskUserQuestion') {
           console.log(`[claude-sdk] Intercepted AskUserQuestion (toolUseID: ${options.toolUseID})`);
 

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -703,7 +703,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     const gen = query({ prompt: promptIterable, options });
 
     let output = '';
-    let success = true;
+    let success = false;
     let errorMessage: string | undefined;
     let resultMetrics: TaskResult['metrics'] | undefined;
 
@@ -1077,7 +1077,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     });
 
     let output = '';
-    let success = true;
+    let success = false;
     let errorMessage: string | undefined;
     const artifacts: TaskArtifact[] = [];
     let progress = 0;
@@ -1265,6 +1265,14 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     }
 
     console.log(`[claude-sdk] Task ${task.id} for-await loop exited: ${receivedResult ? 'received result message (normal)' : 'generator exhausted without result message'}`);
+
+    // If the stream ended without a result message, the process likely crashed
+    // or hit a limit not covered by the SDK's result subtypes.
+    if (!receivedResult && success) {
+      success = false;
+      errorMessage ??= 'Agent process exited without producing a result message';
+      stream.status('failed', progress, errorMessage);
+    }
 
     // Detect unauthenticated Claude Code sessions.
     // When the keychain token is missing (common on remote/HPC machines), the CLI

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -41,7 +41,7 @@ const claudeExecutablePath = resolveClaudeExecutable();
 import type { Task, TaskResult, TaskArtifact, ExecutionSummary, HpcCapability } from '../types.js';
 import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
 import { type ProviderAdapter, type NormalizedTask, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse, getAugmentedPath } from './base-adapter.js';
-import { isPathUnderReferenceMount } from '../lib/additional-folders.js';
+import { buildReferenceFolderDenyHook } from '../lib/reference-folder-guard.js';
 import { buildHpcContext, type HpcContext } from '../lib/hpc-context.js';
 import type { SlurmJobMonitor } from '../lib/slurm-job-monitor.js';
 import { config } from '../lib/config.js';
@@ -49,88 +49,6 @@ import { config } from '../lib/config.js';
 /** Shell execution tools whose output may contain real sbatch submissions */
 const SHELL_TOOLS = new Set(['Bash', 'bash', 'shell', 'execute_command', 'terminal']);
 
-/**
- * Tools that can mutate the filesystem and must be denied when their target
- * resolves under a reference-mode additional folder.
- */
-const WRITE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
-
-/**
- * Extract candidate filesystem paths from a tool input. Returns every path
- * that should be checked against the reference-mount guard. Covers the
- * built-in Edit/Write/NotebookEdit inputs and best-effort Bash parsing.
- */
-function extractPathsForWriteCheck(toolName: string, input: Record<string, unknown>): string[] {
-  const paths: string[] = [];
-  const pushIfString = (v: unknown): void => {
-    if (typeof v === 'string' && v.length > 0) paths.push(v);
-  };
-
-  if (toolName === 'Edit' || toolName === 'Write' || toolName === 'NotebookEdit' || toolName === 'MultiEdit') {
-    pushIfString((input as { file_path?: unknown }).file_path);
-    pushIfString((input as { notebook_path?: unknown }).notebook_path);
-    pushIfString((input as { path?: unknown }).path);
-    // MultiEdit: edits[].file_path
-    const edits = (input as { edits?: unknown }).edits;
-    if (Array.isArray(edits)) {
-      for (const e of edits) {
-        if (e && typeof e === 'object') {
-          pushIfString((e as { file_path?: unknown }).file_path);
-        }
-      }
-    }
-    return paths;
-  }
-
-  if (toolName === 'Bash' || toolName === 'bash') {
-    const cmd = (input as { command?: unknown }).command;
-    if (typeof cmd === 'string') {
-      // Best-effort: tokenize and keep anything that looks like a path
-      // argument (starts with /, ./, ../, or ~/). The reference-mount guard
-      // only fires on paths under a known reference root, so false positives
-      // on unrelated tokens are harmless.
-      const tokens = cmd.split(/\s+/);
-      for (const t of tokens) {
-        const unquoted = t.replace(/^['"]|['"]$/g, '');
-        if (unquoted.startsWith('/') || unquoted.startsWith('./') || unquoted.startsWith('../') || unquoted.startsWith('~/')) {
-          paths.push(unquoted);
-        }
-      }
-    }
-  }
-  return paths;
-}
-
-/**
- * Build a canUseTool wrapper that denies write/edit/bash calls whose target
- * resolves under any reference-mode additional folder. When `referenceMountPaths`
- * is empty, returns `undefined` so callers can skip installing the wrapper.
- */
-function buildReferenceFolderDenyHook(
-  referenceMountPaths: readonly string[],
-  stream?: { toolResult?: (toolName: string, result: unknown, success: boolean, toolUseId?: string) => void },
-): ((toolName: string, input: Record<string, unknown>, toolUseID: string) => { denied: boolean; message?: string }) | undefined {
-  if (referenceMountPaths.length === 0) return undefined;
-
-  return (toolName: string, input: Record<string, unknown>, toolUseID: string) => {
-    if (!WRITE_TOOLS.has(toolName) && toolName !== 'Bash' && toolName !== 'bash') {
-      return { denied: false };
-    }
-
-    const candidates = extractPathsForWriteCheck(toolName, input);
-    for (const p of candidates) {
-      if (isPathUnderReferenceMount(p, referenceMountPaths)) {
-        const message =
-          `Denied: ${toolName} targets a read-only reference folder (${p}). ` +
-          `Reference folders are mounted read-only and cannot be modified.`;
-        // Surface the denial to the UI as a failed tool_result, not a silent no-op.
-        stream?.toolResult?.(toolName, message, false, toolUseID);
-        return { denied: true, message };
-      }
-    }
-    return { denied: false };
-  };
-}
 
 /**
  * Determine whether to enable sandbox mode for Claude Code.
@@ -879,7 +797,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     const referenceMountPaths = resolvedAdditionalFolders
       .filter((m) => m.mode === 'reference')
       .map((m) => m.mountPath);
-    const referenceDenyHook = buildReferenceFolderDenyHook(referenceMountPaths, stream);
+    const referenceDenyHook = buildReferenceFolderDenyHook(referenceMountPaths);
 
     // Build options for the query
     const options: Parameters<typeof query>[0]['options'] = {
@@ -923,7 +841,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
         // Deny write/edit/bash calls that target read-only reference folders.
         // This runs first so the denial is surfaced before any other handling.
         if (referenceDenyHook) {
-          const check = referenceDenyHook(toolName, input, options.toolUseID);
+          const check = referenceDenyHook(toolName, input)
           if (check.denied) {
             return {
               behavior: 'deny' as const,

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -342,6 +342,16 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
    * Resume a completed task session to continue execution.
    * Uses the SDK's `resume` option to reconnect to a previous session.
    * This enables post-completion steering (follow-up questions after task finishes).
+   *
+   * Note on additional folders: working-mode worktrees are cleaned up when the
+   * original task completes, and reference-mode mounts are not preserved on the
+   * resumed session either (we don't forward `_resolvedAdditionalFolders` here).
+   * This is intentional — by the time resume fires, the working worktrees are
+   * gone from disk, and leaving reference paths out of `additionalDirectories`
+   * means the SDK's sandbox prevents any access, so the reference-folder deny
+   * hook isn't needed on resume. If a user needs follow-up work that touches the
+   * extra folders, they should dispatch a new task rather than steer the
+   * completed one.
    */
   async resumeTask(
     taskId: string,

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -348,6 +348,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     sessionId: string,
     stream: TaskOutputStream,
     signal: AbortSignal,
+    resumeOptions?: { systemPrompt?: string; taskType?: string },
   ): Promise<{ success: boolean; output: string; error?: string }> {
     const abortController = new AbortController();
     const abortHandler = () => abortController.abort();
@@ -381,6 +382,16 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
       // Resume the previous session
       (options as Record<string, unknown>).resume = sessionId;
+
+      // Re-apply caller's system prompt so directives survive taskType
+      // transitions (e.g. chat → plan). Without this, the resumed session
+      // replays the original system prompt baked in at first execution and
+      // plan-mode instructions like "use astro-cli only, don't execute" are
+      // lost — leading to auto-execution on follow-up turns.
+      if (resumeOptions?.systemPrompt) {
+        (options as Record<string, unknown>).systemPrompt = resumeOptions.systemPrompt;
+        console.log(`[claude-sdk] Resume ${taskId.slice(0, 8)}: applied systemPrompt (${resumeOptions.systemPrompt.length} chars, taskType=${resumeOptions.taskType ?? 'unspecified'})`);
+      }
 
       // Load MCP servers from config if available
       const agentConfig = config.getConfig();

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -451,7 +451,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       const gen = query({ prompt: promptIterable, options });
 
       let output = '';
-      let success = true;
+      let success = false;
       let errorMessage: string | undefined;
       let newSessionId = sessionId;
       // Map tool_use_id → tool name for matching results back to uses
@@ -743,6 +743,12 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
         }
         break;
       }
+    }
+
+    // If the stream ended without a result message, treat as failure
+    if (!success && !errorMessage) {
+      errorMessage = 'Agent process exited without producing a result message';
+      stream.status('failed', 0, errorMessage);
     }
 
     return { success, output, error: errorMessage, metrics: resultMetrics };
@@ -1249,6 +1255,11 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           success = false;
           errorMessage = `Task failed: ${msg.subtype}`;
           stream.status('failed', progress, errorMessage);
+        } else {
+          // Unrecognized result subtype — treat as failure with descriptive message
+          success = false;
+          errorMessage = `Task ended with unrecognized result: ${msg.subtype}`;
+          stream.status('failed', progress, errorMessage);
         }
 
         const tokenSummary = usage ? `${usage.input_tokens ?? 0}+${usage.output_tokens ?? 0}` : 'N/A';
@@ -1268,7 +1279,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
 
     // If the stream ended without a result message, the process likely crashed
     // or hit a limit not covered by the SDK's result subtypes.
-    if (!receivedResult && success) {
+    if (!receivedResult) {
       success = false;
       errorMessage ??= 'Agent process exited without producing a result message';
       stream.status('failed', progress, errorMessage);

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -454,6 +454,7 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       let success = false;
       let errorMessage: string | undefined;
       let newSessionId = sessionId;
+      let receivedResult = false;
       // Map tool_use_id → tool name for matching results back to uses
       const resumeToolUseNames = new Map<string, string>();
 
@@ -499,9 +500,18 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           } else {
             success = false;
             errorMessage = `Resume failed: ${msg.subtype}`;
+            stream.status('failed', 0, errorMessage);
           }
+          receivedResult = true;
           break;
         }
+      }
+
+      // If the stream ended without a result message, treat as failure
+      if (!receivedResult) {
+        success = false;
+        errorMessage ??= 'Agent process exited without producing a result message';
+        stream.status('failed', 0, errorMessage);
       }
 
       // Preserve context after resume completes

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,30 @@ export interface Task {
   /** Target branch for worktree creation and PR base (e.g., 'main', 'develop') */
   baseBranch?: string;
 
+  /** Additional folders (working or reference) to mount into the agent session.
+   *  - working: a git worktree is created on the folder's current HEAD and the
+   *    worktree path is mounted read/write.
+   *  - reference: the path is mounted read-only. Edit/Write/Bash operations that
+   *    target files under the path are denied by the tool permission hook. */
+  additionalFolders?: Array<{
+    machineId: string;
+    path: string;
+    mode: 'working' | 'reference';
+  }>;
+
+  /**
+   * Resolved mount information for `additionalFolders`, populated by the
+   * task executor after worktree setup. Not part of the wire payload —
+   * the executor sets this before invoking the provider adapter so the
+   * adapter can wire the paths into the SDK without re-doing setup.
+   * Internal: consumers must treat this as optional.
+   */
+  _resolvedAdditionalFolders?: Array<{
+    hostPath: string;
+    mountPath: string;
+    mode: 'working' | 'reference';
+  }>;
+
   /** Per-component delivery branch (e.g., 'astro/7b19a9-e4f1a2').
    *  In multi-task components, per-task branches are created from this branch.
    *  In singleton components, the agent works directly on this branch. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export type TaskStatus =
  * Dispatch task type — tells the agent runner what kind of work this is.
  * Matches TaskDispatchType in server/types/relay.ts.
  */
-export type TaskDispatchType = 'execution' | 'plan' | 'chat' | 'summarize' | 'playground';
+export type TaskDispatchType = 'execution' | 'plan' | 'chat' | 'summarize' | 'playground' | 'follow-up';
 
 /**
  * A single message in a conversation history.

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,11 +171,19 @@ export interface Task {
   }>;
 
   /**
-   * Resolved mount information for `additionalFolders`, populated by the
-   * task executor after worktree setup. Not part of the wire payload —
-   * the executor sets this before invoking the provider adapter so the
-   * adapter can wire the paths into the SDK without re-doing setup.
-   * Internal: consumers must treat this as optional.
+   * Resolved mount information for `additionalFolders`.
+   *
+   * INVARIANT: this is an executor-to-adapter handoff field only.
+   *   • Set by `task-executor.ts` after `setupAdditionalFolders()` returns,
+   *     before invoking the provider adapter's run method.
+   *   • Consumed by the provider adapter to wire paths into the SDK's
+   *     `additionalDirectories` and the reference-folder deny hook.
+   *   • Never appears in the incoming dispatch payload (the server sends
+   *     `additionalFolders`, which the executor translates into mounts).
+   *   • Never persisted to disk or DB.
+   *
+   * The `_` prefix marks this as private to the executor/adapter pair —
+   * do not read it from other call sites.
    */
   _resolvedAdditionalFolders?: Array<{
     hostPath: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,7 +163,13 @@ export interface Task {
    *  - working: a git worktree is created on the folder's current HEAD and the
    *    worktree path is mounted read/write.
    *  - reference: the path is mounted read-only. Edit/Write/Bash operations that
-   *    target files under the path are denied by the tool permission hook. */
+   *    target files under the path are denied by the tool permission hook.
+   *
+   *  NOTE: currently honored only by the `claude-sdk` provider. The task
+   *  executor rejects the task if this field is set with any other provider,
+   *  so the agent can't silently fail to see the extra folders. If another
+   *  provider adapter gains multi-directory support, remove the guard in
+   *  `task-executor.ts` around `setupAdditionalFolders`. */
   additionalFolders?: Array<{
     machineId: string;
     path: string;


### PR DESCRIPTION
## Summary

Release merge: accumulated 14 changes from `dev` into `main` for publishing v0.6.0.

### Features
- **feat: additional folders support (working + reference) per task** (#198)
- **feat: add follow-up task type for resumed execution with delivery** (#180)
- **feat(resume): re-apply systemPrompt on session resume** (#199)

### Fixes
- **fix: prevent false auto-verify when Claude Code exits with non-zero code** (#197)
- **fix: apply receivedResult guard + failed status to resumeTask**
- **fix: runTextOnlyQuery parity, clearer subtype errors**
- **fix: resumeTask default, unrecognized subtypes, consistency**
- **fix: PR #198 round-2 review — provider parity + resume docs**
- **fix: PR #198 resilience, quoted-path guard, reporting**

### Docs
- **docs: document _resolvedAdditionalFolders executor→adapter handoff invariant**

---

## Release Flow

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#dbeafe', 'primaryBorderColor': '#93c5fd', 'primaryTextColor': '#1e293b', 'lineColor': '#64748b', 'textColor': '#334155', 'fontSize': '14px', 'fontFamily': 'Inter, -apple-system, BlinkMacSystemFont, sans-serif'}}}%%
flowchart LR
    classDef blue fill:#dbeafe,stroke:#93c5fd,color:#1e293b
    classDef green fill:#dcfce7,stroke:#86efac,color:#1e293b
    classDef amber fill:#fef3c7,stroke:#fcd34b,color:#1e293b

    A["dev branch"]:::blue --> B["merge PR"]:::amber
    B --> C["main branch"]:::green
    C --> D["npm version minor"]:::blue
    D --> E["GitHub Release v0.6.0"]:::blue
    E --> F["NPM publish @latest"]:::green
```

## Test Plan
- [ ] `npm run build` passes on main after merge
- [ ] Release Action publishes successfully
- [ ] Astro submodule pointer bumped to v0.6.0