### PR TITLE
feat: session discovery adapters + import RPC

### DIFF
--- a/src/commands/import-sessions.ts
+++ b/src/commands/import-sessions.ts
@@ -49,6 +49,22 @@ interface ImportManifest {
   sessions: ImportManifestEntry[];
 }
 
+/**
+ * Reject (don't silently strip) sessionIds that contain characters unsafe
+ * for a filename. Claude / Codex / Pi all use UUID-shaped or filename-safe
+ * ids; anything with `/`, `\`, `..`, NUL, or other path metacharacters is
+ * hostile and the whole id should be refused rather than normalized into a
+ * different-but-still-valid filename.
+ * Returns the id unchanged if acceptable, or null if hostile.
+ */
+function sanitizeSessionIdForFilename(sessionId: string): string | null {
+  if (!sessionId || sessionId.length > 200) return null;
+  if (sessionId.includes('..')) return null;
+  // Disallow anything outside a conservative filename alphabet.
+  if (!/^[A-Za-z0-9._-]+$/.test(sessionId)) return null;
+  return sessionId;
+}
+
 function rawFilename(provider: ExternalAgentProvider, sessionId: string): string {
   return `${provider}-${sessionId}.jsonl`;
 }
@@ -78,6 +94,19 @@ export async function importSessions(
   const failures: ImportSessionsFailure[] = [];
 
   for (const req of sessions) {
+    // Hostile sessionIds (path traversal, NUL, shell metachars) would escape
+    // the raw dir once interpolated into the destination filename. Guard
+    // before touching the adapter or the filesystem.
+    const safeSessionId = sanitizeSessionIdForFilename(req.sessionId);
+    if (!safeSessionId) {
+      failures.push({
+        provider: req.provider,
+        sessionId: req.sessionId,
+        reason: 'invalid sessionId',
+      });
+      continue;
+    }
+
     const adapter = getAdapter(req.provider);
     if (!adapter) {
       failures.push({
@@ -96,6 +125,9 @@ export async function importSessions(
       continue;
     }
 
+    // Adapter uses the original id (which may differ from the sanitized one
+    // only in characters we'd have rejected above — so any session that
+    // resolves has a id that also survives sanitization).
     const sourcePath = adapter.resolveTranscriptPath(req.sessionId);
     if (!sourcePath) {
       failures.push({
@@ -106,7 +138,7 @@ export async function importSessions(
       continue;
     }
 
-    const destFilename = rawFilename(req.provider, req.sessionId);
+    const destFilename = rawFilename(req.provider, safeSessionId);
     const destPath = join(rawDir, destFilename);
     try {
       await copyFile(sourcePath, destPath);
@@ -121,7 +153,7 @@ export async function importSessions(
       sessionId: req.sessionId,
       originalPath: sourcePath,
       localPath: relative(importsDir, destPath),
-      memoryPath: relative(importsDir, join(memoryDir, memoryFilename(req.provider, req.sessionId))),
+      memoryPath: relative(importsDir, join(memoryDir, memoryFilename(req.provider, safeSessionId))),
       cwd: req.cwd,
       gitBranch: req.gitBranch,
       lastModified: req.lastModified,

--- a/src/commands/import-sessions.ts
+++ b/src/commands/import-sessions.ts
@@ -1,0 +1,151 @@
+/**
+ * Import external agent sessions into an Astro project workspace.
+ *
+ * For each requested session, resolves its transcript path via the matching
+ * discovery adapter and copies the JSONL into
+ *   `<workingDirectory>/.astro/imports/raw/<provider>-<sessionId>.jsonl`.
+ * The memory/ subdirectory is created empty; per-session summaries are
+ * written there later by subagents during planning. A manifest.json at
+ * `.astro/imports/manifest.json` records the import for provenance.
+ *
+ * Per-session failures do not abort the whole import; they accumulate in
+ * `failures[]`. The operation is considered ok as long as the workspace
+ * structure is set up and the manifest is written.
+ */
+
+import { copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { getAdapter } from '../session-discovery/index.js';
+import type {
+  ExternalAgentProvider,
+  ImportManifestEntry,
+  ImportSessionsFailure,
+} from '../types.js';
+
+export interface ImportSessionsInput {
+  workingDirectory: string;
+  sessions: Array<{
+    provider: ExternalAgentProvider;
+    sessionId: string;
+    title: string;
+    cwd?: string;
+    gitBranch?: string;
+    lastModified?: number;
+  }>;
+}
+
+export interface ImportSessionsResult {
+  ok: boolean;
+  manifestPath?: string;
+  rawCount: number;
+  failures: ImportSessionsFailure[];
+  error?: string;
+}
+
+interface ImportManifest {
+  version: 1;
+  importedAt: string;
+  workingDirectory: string;
+  sessions: ImportManifestEntry[];
+}
+
+function rawFilename(provider: ExternalAgentProvider, sessionId: string): string {
+  return `${provider}-${sessionId}.jsonl`;
+}
+
+function memoryFilename(provider: ExternalAgentProvider, sessionId: string): string {
+  return `${provider}-${sessionId}.md`;
+}
+
+export async function importSessions(
+  input: ImportSessionsInput,
+): Promise<ImportSessionsResult> {
+  const { workingDirectory, sessions } = input;
+  if (!workingDirectory) {
+    return { ok: false, rawCount: 0, failures: [], error: 'workingDirectory is required' };
+  }
+  if (!sessions.length) {
+    return { ok: false, rawCount: 0, failures: [], error: 'no sessions requested' };
+  }
+
+  const importsDir = join(workingDirectory, '.astro', 'imports');
+  const rawDir = join(importsDir, 'raw');
+  const memoryDir = join(importsDir, 'memory');
+  await mkdir(rawDir, { recursive: true });
+  await mkdir(memoryDir, { recursive: true });
+
+  const manifestSessions: ImportManifestEntry[] = [];
+  const failures: ImportSessionsFailure[] = [];
+
+  for (const req of sessions) {
+    const adapter = getAdapter(req.provider);
+    if (!adapter) {
+      failures.push({
+        provider: req.provider,
+        sessionId: req.sessionId,
+        reason: `unknown provider ${req.provider}`,
+      });
+      continue;
+    }
+    if (!adapter.isAvailable()) {
+      failures.push({
+        provider: req.provider,
+        sessionId: req.sessionId,
+        reason: `${req.provider} not available on this machine`,
+      });
+      continue;
+    }
+
+    const sourcePath = adapter.resolveTranscriptPath(req.sessionId);
+    if (!sourcePath) {
+      failures.push({
+        provider: req.provider,
+        sessionId: req.sessionId,
+        reason: 'transcript file not found',
+      });
+      continue;
+    }
+
+    const destFilename = rawFilename(req.provider, req.sessionId);
+    const destPath = join(rawDir, destFilename);
+    try {
+      await copyFile(sourcePath, destPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      failures.push({ provider: req.provider, sessionId: req.sessionId, reason: `copy failed: ${msg}` });
+      continue;
+    }
+
+    manifestSessions.push({
+      provider: req.provider,
+      sessionId: req.sessionId,
+      originalPath: sourcePath,
+      localPath: relative(importsDir, destPath),
+      memoryPath: relative(importsDir, join(memoryDir, memoryFilename(req.provider, req.sessionId))),
+      cwd: req.cwd,
+      gitBranch: req.gitBranch,
+      lastModified: req.lastModified,
+      title: req.title,
+    });
+  }
+
+  const manifest: ImportManifest = {
+    version: 1,
+    importedAt: new Date().toISOString(),
+    workingDirectory,
+    sessions: manifestSessions,
+  };
+  const manifestPath = join(importsDir, 'manifest.json');
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+
+  return {
+    ok: manifestSessions.length > 0,
+    manifestPath,
+    rawCount: manifestSessions.length,
+    failures,
+    error:
+      manifestSessions.length === 0
+        ? 'no sessions were imported successfully'
+        : undefined,
+  };
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -26,6 +26,8 @@ import {
   formatSetupHint,
   formatNoProvidersWarning,
 } from '../lib/display.js';
+import { discoverSessions } from '../session-discovery/index.js';
+import { importSessions } from './import-sessions.js';
 import type { RunnerEvent, Task, RepoSetupRequestMessage, RepoDetectRequestMessage, BranchListRequestMessage, GitCheckoutRequestMessage, GitCreateBranchRequestMessage, GitInitRequestMessage } from '../types.js';
 
 interface StartOptions {
@@ -1142,123 +1144,56 @@ export async function startCommand(options: StartOptions = {}): Promise<void> {
         });
       }
     },
-    onSessionsList: (correlationId: string, maxAgeMs?: number) => {
-      log('debug', `Sessions list request received (maxAge=${maxAgeMs ?? 'all'})`, logLevel);
+    onSessionsList: (
+      correlationId: string,
+      maxAgeMs?: number,
+      providers?: import('../types.js').ExternalAgentProvider[],
+      cwd?: string,
+    ) => {
+      log(
+        'debug',
+        `Sessions list request received (maxAge=${maxAgeMs ?? 'all'}, providers=${(providers ?? ['*']).join(',')}, cwd=${cwd ?? '*'})`,
+        logLevel,
+      );
       try {
-        const claudeDir = join(homedir(), '.claude', 'projects');
-        if (!existsSync(claudeDir)) {
-          wsClient.sendSessionsListResponse(correlationId, []);
-          return;
-        }
-
-        // Cutoff timestamp: only include files modified after this time
-        const cutoff = maxAgeMs ? Date.now() - maxAgeMs : 0;
-
-        const sessions: import('../types.js').ClaudeCodeSessionInfo[] = [];
-        const projectDirs = readdirSync(claudeDir, { withFileTypes: true })
-          .filter(d => d.isDirectory());
-
-        for (const projDir of projectDirs) {
-          const projPath = join(claudeDir, projDir.name);
-          const cwd = projDir.name.replace(/^-/, '/').replace(/-/g, '/');
-
-          let jsonlFiles: string[];
-          try {
-            jsonlFiles = readdirSync(projPath).filter(f => f.endsWith('.jsonl'));
-          } catch { continue; }
-
-          for (const file of jsonlFiles) {
-            const sessionId = file.replace('.jsonl', '');
-            const filePath = join(projPath, file);
-            try {
-              const stat = statSync(filePath);
-              // Skip tiny files (likely empty sessions)
-              if (stat.size < 100) continue;
-              // Skip files older than cutoff (fast mtime check, no content read)
-              if (cutoff && stat.mtimeMs < cutoff) continue;
-
-              // Extract metadata from head + last user messages from tail
-              const content = readFileSync(filePath, 'utf-8');
-              let firstPrompt = '';
-              let lastUserMsg = '';
-              let secondLastUserMsg = '';
-              let gitBranch = '';
-              let customTitle = '';
-
-              // Helper: extract user text from entry (any text, no filtering)
-              const getUserText = (entry: Record<string, unknown>): string | null => {
-                if (entry.type !== 'user' || !(entry.message as Record<string, unknown>)?.content) return null;
-                const msg = entry.message as Record<string, unknown>;
-                const textContent = Array.isArray(msg.content)
-                  ? (msg.content as Array<{ type: string; text?: string }>).find((c) => c.type === 'text')?.text || ''
-                  : String(msg.content);
-                return textContent.trim() || null;
-              };
-
-              // Read first ~10 lines for metadata + first prompt
-              const lines = content.split('\n');
-              for (let li = 0; li < Math.min(lines.length, 10); li++) {
-                if (!lines[li].trim()) continue;
-                try {
-                  const entry = JSON.parse(lines[li]);
-                  if (entry.gitBranch && !gitBranch) gitBranch = entry.gitBranch;
-                  if (entry.customTitle) customTitle = entry.customTitle;
-                  if (!firstPrompt) {
-                    const text = getUserText(entry);
-                    if (text) firstPrompt = text.slice(0, 200);
-                  }
-                } catch { /* skip */ }
-              }
-
-              // Read last ~16KB to find last two user messages
-              const tailStart = Math.max(0, content.length - 16384);
-              const tailLines = content.slice(tailStart).split('\n');
-              for (let li = tailLines.length - 1; li >= 0; li--) {
-                if (!tailLines[li].trim()) continue;
-                try {
-                  const entry = JSON.parse(tailLines[li]);
-                  const text = getUserText(entry);
-                  if (text) {
-                    if (!lastUserMsg) { lastUserMsg = text.slice(0, 200); }
-                    else if (!secondLastUserMsg) { secondLastUserMsg = text.slice(0, 200); break; }
-                  }
-                } catch { /* skip */ }
-              }
-
-              // Summary: use second-to-last user msg if last is noisy, else last, else first
-              const isNoisy = (t: string) => /^\s*\[/.test(t) || /^\s*</.test(t) || t.trim().length < 5;
-              let summary = '';
-              if (lastUserMsg && !isNoisy(lastUserMsg)) {
-                summary = lastUserMsg.slice(0, 100);
-              } else if (secondLastUserMsg && !isNoisy(secondLastUserMsg)) {
-                summary = secondLastUserMsg.slice(0, 100);
-              } else {
-                summary = (lastUserMsg || firstPrompt).slice(0, 100);
-              }
-
-              sessions.push({
-                sessionId,
-                summary,
-                lastModified: stat.mtimeMs,
-                fileSize: stat.size,
-                customTitle,
-                firstPrompt: firstPrompt || lastUserMsg,
-                gitBranch,
-                cwd,
-              });
-            } catch { /* skip unreadable files */ }
-          }
-        }
-
-        // Sort by lastModified descending, limit to 50 most recent
-        sessions.sort((a, b) => b.lastModified - a.lastModified);
-        const result = sessions.slice(0, 50);
-
-        wsClient.sendSessionsListResponse(correlationId, result);
-        log('debug', `Sent ${result.length} sessions (scanned with cutoff)`, logLevel);
+        const sessions = discoverSessions({ maxAgeMs, providers, cwd, limit: 50 });
+        wsClient.sendSessionsListResponse(correlationId, sessions);
+        log('debug', `Sent ${sessions.length} sessions`, logLevel);
       } catch (error) {
-        log('warn', `Failed to list sessions: ${error instanceof Error ? error.message : String(error)}`, logLevel);
-        wsClient.sendSessionsListResponse(correlationId, [], error instanceof Error ? error.message : String(error));
+        log(
+          'warn',
+          `Failed to list sessions: ${error instanceof Error ? error.message : String(error)}`,
+          logLevel,
+        );
+        wsClient.sendSessionsListResponse(
+          correlationId,
+          [],
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    },
+    onImportSessions: async (
+      correlationId: string,
+      workingDirectory: string,
+      requested: import('../types.js').ImportSessionsRequestMessage['payload']['sessions'],
+    ) => {
+      log(
+        'debug',
+        `Import sessions request received (count=${requested.length}, workingDir=${workingDirectory})`,
+        logLevel,
+      );
+      try {
+        const result = await importSessions({ workingDirectory, sessions: requested });
+        wsClient.sendImportSessionsResponse(correlationId, result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log('warn', `Import sessions failed: ${message}`, logLevel);
+        wsClient.sendImportSessionsResponse(correlationId, {
+          ok: false,
+          rawCount: 0,
+          failures: [],
+          error: message,
+        });
       }
     },
   });

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -126,7 +126,17 @@ export interface WebSocketClientOptions {
   onGitCheckout?: (payload: GitCheckoutRequestMessage['payload']) => void;
   onGitCreateBranch?: (payload: GitCreateBranchRequestMessage['payload']) => void;
   onGitInit?: (payload: GitInitRequestMessage['payload']) => void;
-  onSessionsList?: (correlationId: string, maxAgeMs?: number) => void;
+  onSessionsList?: (
+    correlationId: string,
+    maxAgeMs?: number,
+    providers?: import('../types.js').ExternalAgentProvider[],
+    cwd?: string,
+  ) => void;
+  onImportSessions?: (
+    correlationId: string,
+    workingDirectory: string,
+    sessions: import('../types.js').ImportSessionsRequestMessage['payload']['sessions'],
+  ) => void;
   onOpenClawBridgeReady?: (bridge: OpenClawBridge) => void;
   version?: string;
   wsToken?: string;
@@ -171,6 +181,7 @@ type IncomingMessage =
   | GitCreateBranchRequestMessage
   | GitInitRequestMessage
   | import('../types.js').SessionsListRequestMessage
+  | import('../types.js').ImportSessionsRequestMessage
   | ChannelNotificationMessage
   | ChannelResponseMessage
   | ChannelApprovalRequestMessage
@@ -219,7 +230,17 @@ export class WebSocketClient {
   private onGitCheckout?: (payload: GitCheckoutRequestMessage['payload']) => void;
   private onGitCreateBranch?: (payload: GitCreateBranchRequestMessage['payload']) => void;
   private onGitInit?: (payload: GitInitRequestMessage['payload']) => void;
-  private onSessionsList?: (correlationId: string, maxAgeMs?: number) => void;
+  private onSessionsList?: (
+    correlationId: string,
+    maxAgeMs?: number,
+    providers?: import('../types.js').ExternalAgentProvider[],
+    cwd?: string,
+  ) => void;
+  private onImportSessions?: (
+    correlationId: string,
+    workingDirectory: string,
+    sessions: import('../types.js').ImportSessionsRequestMessage['payload']['sessions'],
+  ) => void;
   private onOpenClawBridgeReady?: (bridge: OpenClawBridge) => void;
 
   constructor(options: WebSocketClientOptions) {
@@ -251,6 +272,7 @@ export class WebSocketClient {
     this.onGitCreateBranch = options.onGitCreateBranch;
     this.onGitInit = options.onGitInit;
     this.onSessionsList = options.onSessionsList;
+    this.onImportSessions = options.onImportSessions;
     this.onOpenClawBridgeReady = options.onOpenClawBridgeReady;
   }
 
@@ -1006,6 +1028,9 @@ export class WebSocketClient {
       case 'sessions_list_request':
         this.handleSessionsListRequest(message as import('../types.js').SessionsListRequestMessage);
         break;
+      case 'import_sessions_request':
+        this.handleImportSessionsRequest(message as import('../types.js').ImportSessionsRequestMessage);
+        break;
       case 'channel_notification':
         this.handleChannelNotification(message as ChannelNotificationMessage);
         break;
@@ -1529,7 +1554,12 @@ export class WebSocketClient {
   }
 
   private handleSessionsListRequest(message: import('../types.js').SessionsListRequestMessage): void {
-    this.onSessionsList?.(message.payload.correlationId, message.payload.maxAgeMs);
+    this.onSessionsList?.(
+      message.payload.correlationId,
+      message.payload.maxAgeMs,
+      message.payload.providers,
+      message.payload.cwd,
+    );
   }
 
   /**
@@ -1544,6 +1574,31 @@ export class WebSocketClient {
       type: 'sessions_list_response',
       timestamp: new Date().toISOString(),
       payload: { correlationId, sessions, error },
+    };
+    this.send(msg);
+  }
+
+  private handleImportSessionsRequest(
+    message: import('../types.js').ImportSessionsRequestMessage,
+  ): void {
+    this.onImportSessions?.(
+      message.payload.correlationId,
+      message.payload.workingDirectory,
+      message.payload.sessions,
+    );
+  }
+
+  /**
+   * Send import sessions response
+   */
+  sendImportSessionsResponse(
+    correlationId: string,
+    result: Omit<import('../types.js').ImportSessionsResponseMessage['payload'], 'correlationId'>,
+  ): void {
+    const msg: import('../types.js').ImportSessionsResponseMessage = {
+      type: 'import_sessions_response',
+      timestamp: new Date().toISOString(),
+      payload: { correlationId, ...result },
     };
     this.send(msg);
   }

--- a/src/session-discovery/adapters/claude.ts
+++ b/src/session-discovery/adapters/claude.ts
@@ -1,0 +1,198 @@
+/**
+ * Claude Code session discovery adapter.
+ *
+ * Walks `~/.claude/projects/<cwd-encoded>/*.jsonl`, where the directory name
+ * is the cwd with leading `/` and internal `/` characters replaced by `-`.
+ * Each .jsonl file is a session; metadata is extracted from head + tail
+ * slices without reading the entire file.
+ *
+ * Lifted from the prior inline implementation in `commands/start.ts` and
+ * preserved verbatim for behavior parity.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  DiscoveryOptions,
+  ExternalAgentSessionInfo,
+  SessionDiscoveryAdapter,
+} from '../types.js';
+
+const PROVIDER = 'claude' as const;
+const HEAD_LINES = 10;
+const TAIL_BYTES = 16_384;
+const SUMMARY_MAX = 100;
+const PROMPT_MAX = 200;
+const MIN_FILE_BYTES = 100;
+
+function rootDir(): string {
+  return join(homedir(), '.claude', 'projects');
+}
+
+/** Decode a Claude project directory name back to an absolute cwd path. */
+function decodeCwd(dirName: string): string {
+  return dirName.replace(/^-/, '/').replace(/-/g, '/');
+}
+
+/** Encode a cwd back to a Claude project directory name (inverse of decode). */
+function encodeCwd(cwd: string): string {
+  return cwd.replace(/\//g, '-');
+}
+
+function getUserText(entry: Record<string, unknown>): string | null {
+  if (entry.type !== 'user' || !(entry.message as Record<string, unknown>)?.content) return null;
+  const msg = entry.message as Record<string, unknown>;
+  const textContent = Array.isArray(msg.content)
+    ? (msg.content as Array<{ type: string; text?: string }>).find((c) => c.type === 'text')?.text || ''
+    : String(msg.content);
+  return textContent.trim() || null;
+}
+
+function isNoisy(t: string): boolean {
+  return /^\s*\[/.test(t) || /^\s*</.test(t) || t.trim().length < 5;
+}
+
+function extractMetadata(content: string): {
+  firstPrompt: string;
+  lastUserMsg: string;
+  secondLastUserMsg: string;
+  gitBranch: string;
+  customTitle: string;
+} {
+  let firstPrompt = '';
+  let lastUserMsg = '';
+  let secondLastUserMsg = '';
+  let gitBranch = '';
+  let customTitle = '';
+
+  const lines = content.split('\n');
+  for (let li = 0; li < Math.min(lines.length, HEAD_LINES); li++) {
+    if (!lines[li].trim()) continue;
+    try {
+      const entry = JSON.parse(lines[li]);
+      if (entry.gitBranch && !gitBranch) gitBranch = entry.gitBranch;
+      if (entry.customTitle) customTitle = entry.customTitle;
+      if (!firstPrompt) {
+        const text = getUserText(entry);
+        if (text) firstPrompt = text.slice(0, PROMPT_MAX);
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  const tailStart = Math.max(0, content.length - TAIL_BYTES);
+  const tailLines = content.slice(tailStart).split('\n');
+  for (let li = tailLines.length - 1; li >= 0; li--) {
+    if (!tailLines[li].trim()) continue;
+    try {
+      const entry = JSON.parse(tailLines[li]);
+      const text = getUserText(entry);
+      if (text) {
+        if (!lastUserMsg) {
+          lastUserMsg = text.slice(0, PROMPT_MAX);
+        } else if (!secondLastUserMsg) {
+          secondLastUserMsg = text.slice(0, PROMPT_MAX);
+          break;
+        }
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  return { firstPrompt, lastUserMsg, secondLastUserMsg, gitBranch, customTitle };
+}
+
+export const claudeAdapter: SessionDiscoveryAdapter = {
+  provider: PROVIDER,
+
+  isAvailable(): boolean {
+    return existsSync(rootDir());
+  },
+
+  listSessions(opts: DiscoveryOptions): ExternalAgentSessionInfo[] {
+    const claudeDir = rootDir();
+    if (!existsSync(claudeDir)) return [];
+
+    const cutoff = opts.maxAgeMs ? Date.now() - opts.maxAgeMs : 0;
+    const sessions: ExternalAgentSessionInfo[] = [];
+
+    let projectDirs: Array<{ name: string }>;
+    try {
+      projectDirs = readdirSync(claudeDir, { withFileTypes: true }).filter((d) => d.isDirectory());
+    } catch {
+      return [];
+    }
+
+    for (const projDir of projectDirs) {
+      const projPath = join(claudeDir, projDir.name);
+      const cwd = decodeCwd(projDir.name);
+      if (opts.cwd && opts.cwd !== cwd) continue;
+
+      let jsonlFiles: string[];
+      try {
+        jsonlFiles = readdirSync(projPath).filter((f) => f.endsWith('.jsonl'));
+      } catch {
+        continue;
+      }
+
+      for (const file of jsonlFiles) {
+        const sessionId = file.replace('.jsonl', '');
+        const filePath = join(projPath, file);
+        try {
+          const stat = statSync(filePath);
+          if (stat.size < MIN_FILE_BYTES) continue;
+          if (cutoff && stat.mtimeMs < cutoff) continue;
+
+          const content = readFileSync(filePath, 'utf-8');
+          const { firstPrompt, lastUserMsg, secondLastUserMsg, gitBranch, customTitle } =
+            extractMetadata(content);
+
+          let summary = '';
+          if (lastUserMsg && !isNoisy(lastUserMsg)) summary = lastUserMsg.slice(0, SUMMARY_MAX);
+          else if (secondLastUserMsg && !isNoisy(secondLastUserMsg))
+            summary = secondLastUserMsg.slice(0, SUMMARY_MAX);
+          else summary = (lastUserMsg || firstPrompt).slice(0, SUMMARY_MAX);
+
+          sessions.push({
+            provider: PROVIDER,
+            sessionId,
+            summary,
+            lastModified: stat.mtimeMs,
+            fileSize: stat.size,
+            customTitle: customTitle || undefined,
+            firstPrompt: firstPrompt || lastUserMsg || undefined,
+            gitBranch: gitBranch || undefined,
+            cwd,
+            transcriptPath: filePath,
+          });
+        } catch {
+          /* skip unreadable files */
+        }
+      }
+    }
+
+    return sessions;
+  },
+
+  resolveTranscriptPath(sessionId: string): string | null {
+    const claudeDir = rootDir();
+    if (!existsSync(claudeDir)) return null;
+    let projectDirs: string[];
+    try {
+      projectDirs = readdirSync(claudeDir);
+    } catch {
+      return null;
+    }
+    for (const dir of projectDirs) {
+      const candidate = join(claudeDir, dir, `${sessionId}.jsonl`);
+      if (existsSync(candidate)) return candidate;
+    }
+    return null;
+  },
+};
+
+// Exported for tests and cross-adapter reuse.
+export const __testing = { decodeCwd, encodeCwd, extractMetadata, isNoisy };

--- a/src/session-discovery/adapters/codex.ts
+++ b/src/session-discovery/adapters/codex.ts
@@ -1,0 +1,215 @@
+/**
+ * Codex session discovery adapter.
+ *
+ * Codex stores sessions under `~/.codex/sessions/YYYY/MM/DD/rollout-<ISO>-<uuid>.jsonl`.
+ * The first line is a `session_meta` record carrying the session id, cwd,
+ * and git metadata. Subsequent lines are events (response_item, turn_context,
+ * etc.) — we don't need them for listing.
+ *
+ * The summary is derived from the first user input we can find in the
+ * opening ~30 lines; falling back to the session's cwd/branch when empty.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  DiscoveryOptions,
+  ExternalAgentSessionInfo,
+  SessionDiscoveryAdapter,
+} from '../types.js';
+
+const PROVIDER = 'codex' as const;
+const HEAD_LINES_SUMMARY = 30;
+const SUMMARY_MAX = 100;
+const PROMPT_MAX = 200;
+const MIN_FILE_BYTES = 100;
+
+function rootDir(): string {
+  return join(homedir(), '.codex', 'sessions');
+}
+
+interface ParsedMeta {
+  sessionId: string;
+  cwd?: string;
+  gitBranch?: string;
+  firstUserPrompt?: string;
+}
+
+function parseCodexHead(content: string): ParsedMeta | null {
+  const lines = content.split('\n');
+  if (lines.length === 0) return null;
+
+  let meta: ParsedMeta | null = null;
+  let firstUserPrompt: string | undefined;
+
+  for (let i = 0; i < Math.min(lines.length, HEAD_LINES_SUMMARY); i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (entry.type === 'session_meta' && entry.payload && typeof entry.payload === 'object') {
+      const p = entry.payload as Record<string, unknown>;
+      const id = typeof p.id === 'string' ? p.id : '';
+      const cwd = typeof p.cwd === 'string' ? p.cwd : undefined;
+      const git = (p.git ?? null) as Record<string, unknown> | null;
+      const gitBranch = git && typeof git.branch === 'string' ? git.branch : undefined;
+      meta = { sessionId: id, cwd, gitBranch };
+      continue;
+    }
+
+    // Extract the first user-authored text we encounter. The Codex rollout
+    // format uses `response_item` entries with a `payload.content` array.
+    if (!firstUserPrompt && entry.type === 'response_item' && entry.payload) {
+      const p = entry.payload as Record<string, unknown>;
+      if (p.role === 'user' && Array.isArray(p.content)) {
+        const textBlock = (p.content as Array<Record<string, unknown>>).find(
+          (b) => typeof b.text === 'string',
+        );
+        if (textBlock) {
+          firstUserPrompt = String(textBlock.text).trim().slice(0, PROMPT_MAX);
+        }
+      }
+    }
+  }
+
+  if (!meta) return null;
+  if (firstUserPrompt) meta.firstUserPrompt = firstUserPrompt;
+  return meta;
+}
+
+function extractSessionIdFromFilename(filename: string): string {
+  // rollout-<ISO>-<uuid>.jsonl → last UUID-shaped chunk
+  const stripped = filename.replace(/\.jsonl$/, '');
+  const parts = stripped.split('-');
+  if (parts.length >= 5) {
+    // uuid is the last 5 dash-separated fields
+    return parts.slice(-5).join('-');
+  }
+  return stripped;
+}
+
+function* walkDatedDirs(root: string): Generator<string> {
+  // ~/.codex/sessions/YYYY/MM/DD/*.jsonl — but also tolerate flat layouts.
+  let years: string[];
+  try {
+    years = readdirSync(root, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return;
+  }
+
+  for (const year of years) {
+    const yearPath = join(root, year);
+    let months: string[];
+    try {
+      months = readdirSync(yearPath, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
+    } catch {
+      continue;
+    }
+    for (const month of months) {
+      const monthPath = join(yearPath, month);
+      let days: string[];
+      try {
+        days = readdirSync(monthPath, { withFileTypes: true })
+          .filter((d) => d.isDirectory())
+          .map((d) => d.name);
+      } catch {
+        continue;
+      }
+      for (const day of days) {
+        const dayPath = join(monthPath, day);
+        let files: string[];
+        try {
+          files = readdirSync(dayPath).filter((f) => f.endsWith('.jsonl'));
+        } catch {
+          continue;
+        }
+        for (const f of files) yield join(dayPath, f);
+      }
+    }
+  }
+
+  // Also check for flat .jsonl files at root (legacy).
+  try {
+    const flat = readdirSync(root).filter((f) => f.endsWith('.jsonl'));
+    for (const f of flat) yield join(root, f);
+  } catch {
+    /* ignore */
+  }
+}
+
+export const codexAdapter: SessionDiscoveryAdapter = {
+  provider: PROVIDER,
+
+  isAvailable(): boolean {
+    return existsSync(rootDir());
+  },
+
+  listSessions(opts: DiscoveryOptions): ExternalAgentSessionInfo[] {
+    const root = rootDir();
+    if (!existsSync(root)) return [];
+    const cutoff = opts.maxAgeMs ? Date.now() - opts.maxAgeMs : 0;
+    const sessions: ExternalAgentSessionInfo[] = [];
+
+    for (const filePath of walkDatedDirs(root)) {
+      try {
+        const stat = statSync(filePath);
+        if (stat.size < MIN_FILE_BYTES) continue;
+        if (cutoff && stat.mtimeMs < cutoff) continue;
+
+        // Only need the first ~8KB for metadata; the first line alone may be
+        // many KB (session_meta carries base instructions), so read 32KB.
+        const content = readFileSync(filePath, 'utf-8').slice(0, 32_768);
+        const meta = parseCodexHead(content);
+        if (!meta) continue;
+        if (opts.cwd && meta.cwd !== opts.cwd) continue;
+
+        const basename = filePath.split('/').pop() || '';
+        const sessionId = meta.sessionId || extractSessionIdFromFilename(basename);
+        const summary = (meta.firstUserPrompt || meta.cwd || '').slice(0, SUMMARY_MAX);
+
+        sessions.push({
+          provider: PROVIDER,
+          sessionId,
+          summary,
+          lastModified: stat.mtimeMs,
+          fileSize: stat.size,
+          firstPrompt: meta.firstUserPrompt,
+          gitBranch: meta.gitBranch,
+          cwd: meta.cwd,
+          transcriptPath: filePath,
+        });
+      } catch {
+        /* skip unreadable files */
+      }
+    }
+
+    return sessions;
+  },
+
+  resolveTranscriptPath(sessionId: string): string | null {
+    const root = rootDir();
+    if (!existsSync(root)) return null;
+    for (const filePath of walkDatedDirs(root)) {
+      try {
+        const content = readFileSync(filePath, 'utf-8').slice(0, 32_768);
+        const meta = parseCodexHead(content);
+        if (meta?.sessionId === sessionId) return filePath;
+      } catch {
+        /* skip */
+      }
+    }
+    return null;
+  },
+};
+
+export const __testing = { parseCodexHead, extractSessionIdFromFilename, walkDatedDirs };

--- a/src/session-discovery/adapters/pi.ts
+++ b/src/session-discovery/adapters/pi.ts
@@ -1,0 +1,214 @@
+/**
+ * Pi coding agent session discovery adapter.
+ *
+ * Pi stores sessions under
+ *   `~/.pi/agent/sessions/--<path>--/<timestamp>_<uuid>.jsonl`
+ * where `<path>` is the cwd with `/` replaced by `-`. The first line is a
+ * session header (`{type: "session", version, id, timestamp, cwd}`);
+ * subsequent lines are tree-linked messages.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  DiscoveryOptions,
+  ExternalAgentSessionInfo,
+  SessionDiscoveryAdapter,
+} from '../types.js';
+
+const PROVIDER = 'pi' as const;
+const HEAD_LINES_SCAN = 50;
+const TAIL_BYTES = 16_384;
+const SUMMARY_MAX = 100;
+const PROMPT_MAX = 200;
+const MIN_FILE_BYTES = 100;
+
+function rootDir(): string {
+  return join(homedir(), '.pi', 'agent', 'sessions');
+}
+
+/** Decode Pi's `--<cwd-with-dashes>--` directory name back to an absolute path. */
+function decodeCwd(dirName: string): string {
+  const inner = dirName.replace(/^--/, '').replace(/--$/, '');
+  return '/' + inner.replace(/-/g, '/');
+}
+
+interface PiHeader {
+  sessionId: string;
+  cwd?: string;
+  timestamp?: string;
+}
+
+function parsePiHeader(content: string): PiHeader | null {
+  const firstNewline = content.indexOf('\n');
+  const firstLine = firstNewline === -1 ? content : content.slice(0, firstNewline);
+  if (!firstLine.trim()) return null;
+  try {
+    const entry = JSON.parse(firstLine);
+    if (entry?.type !== 'session' || typeof entry.id !== 'string') return null;
+    return {
+      sessionId: entry.id,
+      cwd: typeof entry.cwd === 'string' ? entry.cwd : undefined,
+      timestamp: typeof entry.timestamp === 'string' ? entry.timestamp : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function extractUserPrompt(line: string): string | null {
+  try {
+    const entry = JSON.parse(line);
+    if (entry?.type !== 'message') return null;
+    const msg = entry.message as Record<string, unknown> | undefined;
+    if (!msg || msg.role !== 'user') return null;
+    const content = msg.content;
+    if (Array.isArray(content)) {
+      const text = (content as Array<Record<string, unknown>>).find(
+        (b) => b.type === 'text' && typeof b.text === 'string',
+      );
+      if (text) return String(text.text).trim();
+    } else if (typeof content === 'string') {
+      return content.trim();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isNoisy(t: string): boolean {
+  return /^\s*\[/.test(t) || /^\s*</.test(t) || t.trim().length < 5;
+}
+
+export const piAdapter: SessionDiscoveryAdapter = {
+  provider: PROVIDER,
+
+  isAvailable(): boolean {
+    return existsSync(rootDir());
+  },
+
+  listSessions(opts: DiscoveryOptions): ExternalAgentSessionInfo[] {
+    const root = rootDir();
+    if (!existsSync(root)) return [];
+    const cutoff = opts.maxAgeMs ? Date.now() - opts.maxAgeMs : 0;
+    const sessions: ExternalAgentSessionInfo[] = [];
+
+    let projectDirs: Array<{ name: string }>;
+    try {
+      projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+    } catch {
+      return [];
+    }
+
+    for (const projDir of projectDirs) {
+      const projPath = join(root, projDir.name);
+      const decoded = decodeCwd(projDir.name);
+
+      let files: string[];
+      try {
+        files = readdirSync(projPath).filter((f) => f.endsWith('.jsonl'));
+      } catch {
+        continue;
+      }
+
+      for (const file of files) {
+        const filePath = join(projPath, file);
+        try {
+          const stat = statSync(filePath);
+          if (stat.size < MIN_FILE_BYTES) continue;
+          if (cutoff && stat.mtimeMs < cutoff) continue;
+
+          const content = readFileSync(filePath, 'utf-8');
+          const header = parsePiHeader(content);
+          if (!header) continue;
+          const cwd = header.cwd || decoded;
+          if (opts.cwd && opts.cwd !== cwd) continue;
+
+          // First user prompt from head.
+          const lines = content.split('\n');
+          let firstPrompt = '';
+          for (let li = 1; li < Math.min(lines.length, HEAD_LINES_SCAN); li++) {
+            if (!lines[li].trim()) continue;
+            const p = extractUserPrompt(lines[li]);
+            if (p) {
+              firstPrompt = p.slice(0, PROMPT_MAX);
+              break;
+            }
+          }
+
+          // Last + second-to-last user prompts from tail (for non-noisy summary).
+          const tailStart = Math.max(0, content.length - TAIL_BYTES);
+          const tailLines = content.slice(tailStart).split('\n');
+          let lastUserMsg = '';
+          let secondLastUserMsg = '';
+          for (let li = tailLines.length - 1; li >= 0; li--) {
+            const p = extractUserPrompt(tailLines[li]);
+            if (!p) continue;
+            if (!lastUserMsg) {
+              lastUserMsg = p.slice(0, PROMPT_MAX);
+            } else if (!secondLastUserMsg) {
+              secondLastUserMsg = p.slice(0, PROMPT_MAX);
+              break;
+            }
+          }
+
+          let summary: string;
+          if (lastUserMsg && !isNoisy(lastUserMsg)) summary = lastUserMsg.slice(0, SUMMARY_MAX);
+          else if (secondLastUserMsg && !isNoisy(secondLastUserMsg))
+            summary = secondLastUserMsg.slice(0, SUMMARY_MAX);
+          else summary = (lastUserMsg || firstPrompt).slice(0, SUMMARY_MAX);
+
+          sessions.push({
+            provider: PROVIDER,
+            sessionId: header.sessionId,
+            summary,
+            lastModified: stat.mtimeMs,
+            fileSize: stat.size,
+            firstPrompt: firstPrompt || lastUserMsg || undefined,
+            cwd,
+            transcriptPath: filePath,
+          });
+        } catch {
+          /* skip unreadable files */
+        }
+      }
+    }
+
+    return sessions;
+  },
+
+  resolveTranscriptPath(sessionId: string): string | null {
+    const root = rootDir();
+    if (!existsSync(root)) return null;
+    let projectDirs: string[];
+    try {
+      projectDirs = readdirSync(root);
+    } catch {
+      return null;
+    }
+    for (const dir of projectDirs) {
+      const projPath = join(root, dir);
+      let files: string[];
+      try {
+        files = readdirSync(projPath).filter((f) => f.endsWith('.jsonl'));
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        const candidate = join(projPath, file);
+        try {
+          const firstChunk = readFileSync(candidate, 'utf-8').slice(0, 4_096);
+          const header = parsePiHeader(firstChunk);
+          if (header?.sessionId === sessionId) return candidate;
+        } catch {
+          /* skip */
+        }
+      }
+    }
+    return null;
+  },
+};
+
+export const __testing = { decodeCwd, parsePiHeader, extractUserPrompt, isNoisy };

--- a/src/session-discovery/index.ts
+++ b/src/session-discovery/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Unified session discovery across supported external agents.
+ *
+ * Fans out a single discovery query to every registered adapter and returns
+ * the merged result, sorted newest-first and capped to `limit`. Adapters
+ * whose provider is not in the requested set, or whose root directory does
+ * not exist on this machine, are skipped.
+ */
+
+import { ADAPTERS, getAdapter } from './registry.js';
+import type { DiscoveryOptions, ExternalAgentProvider, ExternalAgentSessionInfo } from './types.js';
+
+export { ADAPTERS, getAdapter };
+export type {
+  DiscoveryOptions,
+  ExternalAgentProvider,
+  ExternalAgentSessionInfo,
+  SessionDiscoveryAdapter,
+} from './types.js';
+
+export interface DiscoverSessionsOptions extends DiscoveryOptions {
+  providers?: ExternalAgentProvider[];
+  /** Cap on total results across all providers. Defaults to 50. */
+  limit?: number;
+}
+
+export function discoverSessions(opts: DiscoverSessionsOptions = {}): ExternalAgentSessionInfo[] {
+  const providerFilter = opts.providers?.length ? new Set(opts.providers) : null;
+  const selected = providerFilter
+    ? ADAPTERS.filter((a) => providerFilter.has(a.provider))
+    : ADAPTERS;
+
+  const all: ExternalAgentSessionInfo[] = [];
+  for (const adapter of selected) {
+    if (!adapter.isAvailable()) continue;
+    try {
+      const items = adapter.listSessions({ maxAgeMs: opts.maxAgeMs, cwd: opts.cwd });
+      all.push(...items);
+    } catch {
+      /* adapter bug: skip rather than fail whole discovery */
+    }
+  }
+
+  all.sort((a, b) => b.lastModified - a.lastModified);
+  const limit = opts.limit ?? 50;
+  return all.slice(0, limit);
+}
+
+/** Resolve a session's transcript path by scanning adapters in order. */
+export function resolveTranscriptPath(
+  provider: ExternalAgentProvider,
+  sessionId: string,
+): string | null {
+  const adapter = getAdapter(provider);
+  if (!adapter || !adapter.isAvailable()) return null;
+  return adapter.resolveTranscriptPath(sessionId);
+}

--- a/src/session-discovery/registry.ts
+++ b/src/session-discovery/registry.ts
@@ -1,0 +1,10 @@
+import { claudeAdapter } from './adapters/claude.js';
+import { codexAdapter } from './adapters/codex.js';
+import { piAdapter } from './adapters/pi.js';
+import type { ExternalAgentProvider, SessionDiscoveryAdapter } from './types.js';
+
+export const ADAPTERS: SessionDiscoveryAdapter[] = [claudeAdapter, codexAdapter, piAdapter];
+
+export function getAdapter(provider: ExternalAgentProvider): SessionDiscoveryAdapter | undefined {
+  return ADAPTERS.find((a) => a.provider === provider);
+}

--- a/src/session-discovery/types.ts
+++ b/src/session-discovery/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Session discovery types.
+ *
+ * An `ExternalAgentSessionInfo` is the normalized shape for a session
+ * produced by any supported agent (Claude Code, Codex, Pi). Adapters walk
+ * their on-disk session directories and emit these; callers treat them
+ * uniformly.
+ */
+
+export type ExternalAgentProvider = 'claude' | 'codex' | 'pi';
+
+export interface ExternalAgentSessionInfo {
+  provider: ExternalAgentProvider;
+  sessionId: string;
+  summary: string;
+  lastModified: number;
+  fileSize: number;
+  customTitle?: string;
+  firstPrompt?: string;
+  gitBranch?: string;
+  cwd?: string;
+  /** Absolute path to the transcript file on this machine. */
+  transcriptPath: string;
+}
+
+export interface DiscoveryOptions {
+  /** Only include sessions modified within this many ms. */
+  maxAgeMs?: number;
+  /** If set, only include sessions whose cwd equals this absolute path. */
+  cwd?: string;
+}
+
+export interface SessionDiscoveryAdapter {
+  readonly provider: ExternalAgentProvider;
+  /** Fast check: does the provider's session directory exist on this machine? */
+  isAvailable(): boolean;
+  /**
+   * Walk the provider's on-disk sessions and emit normalized info.
+   * Must not throw on individual file errors — skip and continue.
+   */
+  listSessions(opts: DiscoveryOptions): ExternalAgentSessionInfo[];
+  /**
+   * Resolve the absolute path to a given session's transcript file, or null
+   * if the session no longer exists. Used by the import command.
+   */
+  resolveTranscriptPath(sessionId: string): string | null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -360,6 +360,7 @@ export type WSMessageType =
   | 'git_create_branch_response'
   | 'git_init_response'
   | 'sessions_list_response'
+  | 'import_sessions_response'
   | 'channel_notification_ack'
   | 'channel_response_ack'
   | 'channel_approval_response'
@@ -388,6 +389,7 @@ export type WSMessageType =
   | 'git_create_branch_request'
   | 'git_init_request'
   | 'sessions_list_request'
+  | 'import_sessions_request'
   | 'channel_notification'
   | 'channel_response'
   | 'channel_approval_request'
@@ -942,15 +944,28 @@ export interface GitInitResponseMessage extends WSMessage {
 // Sessions List Types
 // ============================================================================
 
+export type ExternalAgentProvider = 'claude' | 'codex' | 'pi';
+
 export interface SessionsListRequestMessage extends WSMessage {
   type: 'sessions_list_request';
   payload: {
     correlationId: string;
     /** Only return sessions modified within this many ms. Omit for all sessions. */
     maxAgeMs?: number;
+    /** Restrict to a subset of providers. Omit for all available providers. */
+    providers?: ExternalAgentProvider[];
+    /** If set, only sessions whose cwd equals this absolute path are returned. */
+    cwd?: string;
   };
 }
 
+/**
+ * Normalized session info across Claude Code / Codex / Pi.
+ *
+ * `provider` and `transcriptPath` are optional for backward compatibility
+ * with older consumers: the Claude walker historically did not set them.
+ * New code paths populate both fields for every session.
+ */
 export interface ClaudeCodeSessionInfo {
   sessionId: string;
   summary: string;
@@ -960,6 +975,8 @@ export interface ClaudeCodeSessionInfo {
   firstPrompt?: string;
   gitBranch?: string;
   cwd?: string;
+  provider?: ExternalAgentProvider;
+  transcriptPath?: string;
 }
 
 export interface SessionsListResponseMessage extends WSMessage {
@@ -967,6 +984,66 @@ export interface SessionsListResponseMessage extends WSMessage {
   payload: {
     correlationId: string;
     sessions: ClaudeCodeSessionInfo[];
+    error?: string;
+  };
+}
+
+/**
+ * Request: copy the selected agent sessions' transcripts into
+ * `<workingDirectory>/.astro/imports/` on this machine so subsequent agent
+ * runs can summarize them. Sessions are identified by provider + sessionId;
+ * the agent resolves each to a transcript path via its discovery adapter.
+ */
+export interface ImportSessionsRequestMessage extends WSMessage {
+  type: 'import_sessions_request';
+  payload: {
+    correlationId: string;
+    workingDirectory: string;
+    sessions: Array<{
+      provider: ExternalAgentProvider;
+      sessionId: string;
+      /** Human-readable title, saved into the manifest for UI provenance. */
+      title: string;
+      /** cwd at time of discovery (saved into manifest; not re-validated). */
+      cwd?: string;
+      gitBranch?: string;
+      lastModified?: number;
+    }>;
+  };
+}
+
+export interface ImportManifestEntry {
+  provider: ExternalAgentProvider;
+  sessionId: string;
+  /** Absolute source path at time of copy. */
+  originalPath: string;
+  /** Path of the copied file, relative to `.astro/imports/`. */
+  localPath: string;
+  /** Planned path for the per-session memory file (initially absent). */
+  memoryPath: string;
+  cwd?: string;
+  gitBranch?: string;
+  lastModified?: number;
+  title: string;
+}
+
+export interface ImportSessionsFailure {
+  provider: ExternalAgentProvider;
+  sessionId: string;
+  reason: string;
+}
+
+export interface ImportSessionsResponseMessage extends WSMessage {
+  type: 'import_sessions_response';
+  payload: {
+    correlationId: string;
+    ok: boolean;
+    /** Absolute path of the manifest file written, if any. */
+    manifestPath?: string;
+    /** Number of transcripts successfully copied. */
+    rawCount: number;
+    failures: ImportSessionsFailure[];
+    /** Set when the request aborted before any file was touched. */
     error?: string;
   };
 }

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -112,4 +112,27 @@ describe('importSessions', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBeDefined();
   });
+
+  it('rejects hostile sessionIds (path traversal) before touching the filesystem', async () => {
+    // Guard is at the top of the per-session loop, so we don't need a seeded
+    // transcript — the sanitizer rejects before the adapter is consulted.
+    const result = await importSessions({
+      workingDirectory: workspace,
+      sessions: [
+        { provider: 'claude', sessionId: '../../../etc/passwd', title: 'Hostile', cwd: '/Users/alice/app' },
+        { provider: 'claude', sessionId: 'with/slash', title: 'Also bad' },
+        { provider: 'claude', sessionId: 'nul\0here', title: 'NUL inject' },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(3);
+    for (const f of result.failures) {
+      expect(f.reason).toMatch(/invalid sessionId/);
+    }
+
+    // Nothing should have been written outside the imports/raw/ dir.
+    const traversalTarget = join(workspace, '..', 'etc', 'passwd.jsonl');
+    expect(existsSync(traversalTarget)).toBe(false);
+  });
 });

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Import sessions command tests.
+ *
+ * Seed fake Claude / Codex / Pi session directories under a fake HOME,
+ * then call importSessions() and assert:
+ *  - `<workingDir>/.astro/imports/raw/*.jsonl` files are byte-for-byte copies
+ *  - `manifest.json` is written with correct entries
+ *  - failures[] captures requests that have no matching transcript
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { importSessions } from '../src/commands/import-sessions';
+
+let originalHome: string | undefined;
+let tempHome: string;
+let workspace: string;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  const ts = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  tempHome = join(tmpdir(), `import-sessions-home-${ts}`);
+  workspace = join(tmpdir(), `import-sessions-ws-${ts}`);
+  mkdirSync(tempHome, { recursive: true });
+  mkdirSync(workspace, { recursive: true });
+  process.env.HOME = tempHome;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function seedClaude(cwd: string, sessionId: string, body: string): string {
+  const encoded = cwd.replace(/\//g, '-');
+  const dir = join(tempHome, '.claude', 'projects', encoded);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${sessionId}.jsonl`);
+  writeFileSync(path, body);
+  return path;
+}
+
+function seedPi(cwd: string, sessionId: string, body: string): string {
+  const encoded = `--${cwd.slice(1).replace(/\//g, '-')}--`;
+  const dir = join(tempHome, '.pi', 'agent', 'sessions', encoded);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `2026-04-16T12-00-00-000Z_${sessionId}.jsonl`);
+  const header = JSON.stringify({ type: 'session', version: 3, id: sessionId, timestamp: new Date().toISOString(), cwd });
+  writeFileSync(path, header + '\n' + body);
+  return path;
+}
+
+describe('importSessions', () => {
+  it('copies transcripts and writes a manifest', async () => {
+    const claudeBody = '{"type":"user","message":{"content":"a claude prompt with enough text"}}\n';
+    const claudePath = seedClaude('/Users/alice/app', 'c-1', claudeBody);
+    const piBody = '{"type":"message","id":"m1","timestamp":"2026-04-16T12:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}\n';
+    const piPath = seedPi('/Users/alice/app', 'p-1', piBody);
+
+    const result = await importSessions({
+      workingDirectory: workspace,
+      sessions: [
+        { provider: 'claude', sessionId: 'c-1', title: 'Claude task', cwd: '/Users/alice/app' },
+        { provider: 'pi', sessionId: 'p-1', title: 'Pi task', cwd: '/Users/alice/app' },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.rawCount).toBe(2);
+    expect(result.failures).toEqual([]);
+    expect(result.manifestPath).toBe(join(workspace, '.astro', 'imports', 'manifest.json'));
+
+    // Raw files copied
+    const copiedClaude = join(workspace, '.astro', 'imports', 'raw', 'claude-c-1.jsonl');
+    const copiedPi = join(workspace, '.astro', 'imports', 'raw', 'pi-p-1.jsonl');
+    expect(existsSync(copiedClaude)).toBe(true);
+    expect(existsSync(copiedPi)).toBe(true);
+    expect(readFileSync(copiedClaude, 'utf-8')).toBe(claudeBody);
+    expect(readFileSync(copiedPi, 'utf-8')).toBe(readFileSync(piPath, 'utf-8'));
+
+    // Manifest content
+    const manifest = JSON.parse(readFileSync(result.manifestPath!, 'utf-8'));
+    expect(manifest.version).toBe(1);
+    expect(manifest.workingDirectory).toBe(workspace);
+    expect(manifest.sessions).toHaveLength(2);
+    const claudeEntry = manifest.sessions.find((s: { provider: string }) => s.provider === 'claude');
+    expect(claudeEntry.originalPath).toBe(claudePath);
+    expect(claudeEntry.localPath).toBe('raw/claude-c-1.jsonl');
+    expect(claudeEntry.memoryPath).toBe('memory/claude-c-1.md');
+
+    // memory/ dir is created empty but present
+    expect(existsSync(join(workspace, '.astro', 'imports', 'memory'))).toBe(true);
+  });
+
+  it('records failures for sessions whose transcripts are missing', async () => {
+    const result = await importSessions({
+      workingDirectory: workspace,
+      sessions: [{ provider: 'claude', sessionId: 'nope', title: 'Missing' }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.rawCount).toBe(0);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].reason).toMatch(/not available|not found/);
+  });
+
+  it('rejects empty requests with an error', async () => {
+    const result = await importSessions({ workingDirectory: workspace, sessions: [] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/tests/session-discovery.test.ts
+++ b/tests/session-discovery.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Session discovery adapter tests.
+ *
+ * Each adapter is invoked against a temporary HOME directory populated with
+ * fixture JSONL files matching the provider's on-disk layout. We verify
+ * that listSessions() correctly extracts session id, cwd, summary, and
+ * provider tag; that resolveTranscriptPath() finds the file; and that the
+ * unified discoverSessions() merges + filters by provider / cwd / maxAge.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { claudeAdapter } from '../src/session-discovery/adapters/claude';
+import { codexAdapter } from '../src/session-discovery/adapters/codex';
+import { piAdapter } from '../src/session-discovery/adapters/pi';
+import { discoverSessions } from '../src/session-discovery/index';
+
+// ============================================================================
+// Harness — temporary HOME dir with per-test cleanup
+// ============================================================================
+
+let originalHome: string | undefined;
+let tempHome: string;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  tempHome = join(tmpdir(), `session-discovery-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tempHome, { recursive: true });
+  process.env.HOME = tempHome;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+function writeClaudeSession(cwd: string, sessionId: string, lines: Array<Record<string, unknown>>): string {
+  // Encoding: "/Users/xf2217/foo" -> "-Users-xf2217-foo"
+  const encoded = cwd.replace(/\//g, '-');
+  const dir = join(tempHome, '.claude', 'projects', encoded);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${sessionId}.jsonl`);
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  return path;
+}
+
+function writeCodexSession(
+  ymd: [string, string, string],
+  sessionId: string,
+  cwd: string,
+  opts: { gitBranch?: string; firstUserPrompt?: string } = {},
+): string {
+  const dir = join(tempHome, '.codex', 'sessions', ...ymd);
+  mkdirSync(dir, { recursive: true });
+  const filename = `rollout-${ymd.join('')}T000000-${sessionId}.jsonl`;
+  const path = join(dir, filename);
+  const meta = {
+    timestamp: new Date().toISOString(),
+    type: 'session_meta',
+    payload: {
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd,
+      git: opts.gitBranch ? { branch: opts.gitBranch } : undefined,
+    },
+  };
+  const prompt = opts.firstUserPrompt
+    ? {
+        timestamp: new Date().toISOString(),
+        type: 'response_item',
+        payload: { role: 'user', content: [{ type: 'input_text', text: opts.firstUserPrompt }] },
+      }
+    : null;
+  const lines = [meta, prompt].filter(Boolean);
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  return path;
+}
+
+function writePiSession(cwd: string, sessionId: string, opts: { firstUserPrompt?: string } = {}): string {
+  const encoded = `--${cwd.slice(1).replace(/\//g, '-')}--`;
+  const dir = join(tempHome, '.pi', 'agent', 'sessions', encoded);
+  mkdirSync(dir, { recursive: true });
+  const filename = `2026-04-16T12-00-00-000Z_${sessionId}.jsonl`;
+  const path = join(dir, filename);
+  const header = { type: 'session', version: 3, id: sessionId, timestamp: new Date().toISOString(), cwd };
+  const message = opts.firstUserPrompt
+    ? {
+        type: 'message',
+        id: 'm1',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: [{ type: 'text', text: opts.firstUserPrompt }] },
+      }
+    : null;
+  const lines = [header, message].filter(Boolean);
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  return path;
+}
+
+// ============================================================================
+// Claude adapter
+// ============================================================================
+
+describe('claudeAdapter', () => {
+  it('reports unavailable when ~/.claude/projects does not exist', () => {
+    expect(claudeAdapter.isAvailable()).toBe(false);
+  });
+
+  it('lists sessions with provider tag, cwd, and summary', () => {
+    writeClaudeSession('/Users/alice/app', 'sess-abc', [
+      {
+        type: 'user',
+        message: { content: 'Add tests for the login flow, including session handling and persistent cookies' },
+      },
+    ]);
+    expect(claudeAdapter.isAvailable()).toBe(true);
+    const sessions = claudeAdapter.listSessions({});
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].provider).toBe('claude');
+    expect(sessions[0].sessionId).toBe('sess-abc');
+    expect(sessions[0].cwd).toBe('/Users/alice/app');
+    expect(sessions[0].summary).toContain('Add tests');
+    expect(sessions[0].transcriptPath).toContain('sess-abc.jsonl');
+  });
+
+  it('filters by cwd when requested', () => {
+    writeClaudeSession('/Users/alice/app', 's1', [
+      { type: 'user', message: { content: 'work on the shared app module with the new navigation patterns' } },
+    ]);
+    writeClaudeSession('/Users/alice/other', 's2', [
+      { type: 'user', message: { content: 'work on the other codebase refactor task with big enough padding text' } },
+    ]);
+    const matched = claudeAdapter.listSessions({ cwd: '/Users/alice/app' });
+    expect(matched).toHaveLength(1);
+    expect(matched[0].sessionId).toBe('s1');
+  });
+
+  it('filters by maxAgeMs via mtime check', () => {
+    writeClaudeSession('/Users/alice/app', 'fresh', [
+      { type: 'user', message: { content: 'a message long enough to pass the 100-byte filter blah blah blah' } },
+    ]);
+    // maxAgeMs so small that the just-written file is outside the window
+    const sessions = claudeAdapter.listSessions({ maxAgeMs: -1 });
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('resolveTranscriptPath returns the .jsonl file', () => {
+    const path = writeClaudeSession('/Users/alice/app', 'xyz', [
+      { type: 'user', message: { content: 'hello world and then some more text padding' } },
+    ]);
+    expect(claudeAdapter.resolveTranscriptPath('xyz')).toBe(path);
+    expect(claudeAdapter.resolveTranscriptPath('missing')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Codex adapter
+// ============================================================================
+
+describe('codexAdapter', () => {
+  it('lists sessions from nested YYYY/MM/DD layout', () => {
+    writeCodexSession(['2026', '04', '16'], '019d0972-90f7-7300-a6b5-03af0946668f', '/Users/bob/repo', {
+      gitBranch: 'feat/x',
+      firstUserPrompt: 'Refactor the auth module',
+    });
+    expect(codexAdapter.isAvailable()).toBe(true);
+    const sessions = codexAdapter.listSessions({});
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].provider).toBe('codex');
+    expect(sessions[0].sessionId).toBe('019d0972-90f7-7300-a6b5-03af0946668f');
+    expect(sessions[0].cwd).toBe('/Users/bob/repo');
+    expect(sessions[0].gitBranch).toBe('feat/x');
+    expect(sessions[0].summary).toContain('Refactor');
+  });
+
+  it('filters by cwd', () => {
+    writeCodexSession(['2026', '04', '16'], 'id-1', '/Users/bob/a', { firstUserPrompt: 'do a' });
+    writeCodexSession(['2026', '04', '16'], 'id-2', '/Users/bob/b', { firstUserPrompt: 'do b' });
+    const matched = codexAdapter.listSessions({ cwd: '/Users/bob/b' });
+    expect(matched).toHaveLength(1);
+    expect(matched[0].sessionId).toBe('id-2');
+  });
+
+  it('resolveTranscriptPath locates the rollout file via session_meta id', () => {
+    const path = writeCodexSession(['2026', '04', '16'], 'target-id', '/Users/bob/repo');
+    expect(codexAdapter.resolveTranscriptPath('target-id')).toBe(path);
+    expect(codexAdapter.resolveTranscriptPath('missing')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Pi adapter
+// ============================================================================
+
+describe('piAdapter', () => {
+  it('lists sessions with tree-format JSONL', () => {
+    writePiSession('/Users/carol/proj', 'pi-session-1', { firstUserPrompt: 'build a slug generator' });
+    expect(piAdapter.isAvailable()).toBe(true);
+    const sessions = piAdapter.listSessions({});
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].provider).toBe('pi');
+    expect(sessions[0].sessionId).toBe('pi-session-1');
+    expect(sessions[0].cwd).toBe('/Users/carol/proj');
+    expect(sessions[0].summary).toContain('slug');
+  });
+
+  it('resolveTranscriptPath finds by header sessionId', () => {
+    const path = writePiSession('/Users/carol/proj', 'pi-x', { firstUserPrompt: 'x' });
+    expect(piAdapter.resolveTranscriptPath('pi-x')).toBe(path);
+    expect(piAdapter.resolveTranscriptPath('missing')).toBeNull();
+  });
+});
+
+// ============================================================================
+// discoverSessions — cross-adapter merge
+// ============================================================================
+
+describe('discoverSessions', () => {
+  it('merges and sorts across all three providers', () => {
+    writeClaudeSession('/Users/dave/app', 'claude-1', [
+      { type: 'user', message: { content: 'claude prompt 1 with enough text to survive filtering heuristics' } },
+    ]);
+    writeCodexSession(['2026', '04', '16'], 'codex-1', '/Users/dave/app', { firstUserPrompt: 'codex prompt' });
+    writePiSession('/Users/dave/app', 'pi-1', { firstUserPrompt: 'pi prompt' });
+
+    const all = discoverSessions({});
+    const providers = all.map((s) => s.provider).sort();
+    expect(providers).toEqual(['claude', 'codex', 'pi']);
+  });
+
+  it('respects the providers filter', () => {
+    writeClaudeSession('/Users/dave/app', 'claude-1', [
+      { type: 'user', message: { content: 'claude message long enough long enough long enough long enough' } },
+    ]);
+    writePiSession('/Users/dave/app', 'pi-1', { firstUserPrompt: 'pi prompt' });
+
+    const only = discoverSessions({ providers: ['pi'] });
+    expect(only).toHaveLength(1);
+    expect(only[0].provider).toBe('pi');
+  });
+
+  it('respects the cwd filter across providers', () => {
+    writeClaudeSession('/Users/dave/app', 'c1', [
+      { type: 'user', message: { content: 'a message in app with enough text to survive the filesystem size filter' } },
+    ]);
+    writePiSession('/Users/dave/other', 'p1', { firstUserPrompt: 'a message in the other workspace' });
+    const inApp = discoverSessions({ cwd: '/Users/dave/app' });
+    expect(inApp).toHaveLength(1);
+    expect(inApp[0].sessionId).toBe('c1');
+  });
+
+  it('applies the limit', () => {
+    for (let i = 0; i < 5; i++) {
+      writeClaudeSession('/Users/dave/app', `s-${i}`, [
+        { type: 'user', message: { content: `message ${i} with enough text to survive the filtering heuristics` } },
+      ]);
+    }
+    const limited = discoverSessions({ limit: 2 });
+    expect(limited).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **session-discovery** layer with a plug-in adapter per provider (Claude Code, Codex, Pi), a unified `discoverSessions({providers, cwd, maxAgeMs, limit})` entry point, and per-adapter `resolveTranscriptPath()` lookup.
- Adds a new **`import_sessions_request` / `import_sessions_response`** RPC. The agent-runner copies selected transcripts into `<workingDir>/.astro/imports/raw/`, creates an empty `memory/` sibling, and writes a `manifest.json` so a downstream planning agent can summarize each transcript with a subagent and then synthesize a plan from the summaries.
- Refactors the prior inline Claude walker in `commands/start.ts` to delegate to `discoverSessions()`. Every returned session now carries its `provider` tag; existing consumers that only read the legacy fields continue to work because `provider` + `transcriptPath` are additive optional fields.

## Context

This is the first step of the Astro "Import from history" feature. The inbox in the astro main repo will soon let a user scope to **one machine + one working directory** and pick sessions across Claude Code, Codex, and Pi for import. Because scoping is single-machine, transcripts can be copied locally — no transcript-fetch RPC is required, which is what this PR enables.

A follow-up PR in `astro-anywhere/astro` will wire the picker UI, the `/api/relay/sessions` extensions (`providers=`, `cwd=`), and the dispatch path that triggers `import_sessions_request` before the main planning task runs.

## Test plan

- [x] `npm run build` — clean.
- [x] New unit tests: `tests/session-discovery.test.ts` (14) + `tests/import-sessions.test.ts` (3). Each test stubs `process.env.HOME` to a tmp dir and seeds fake JSONL under `.claude/projects/`, `.codex/sessions/YYYY/MM/DD/`, and `.pi/agent/sessions/--<cwd>--/`.
- [x] Full `npm test` — 990/993 pass; the 3 failures (`tests/directory-list.test.ts` alphabetic sort, two `tests/pi-integration.test.ts` timeouts) are pre-existing on `dev` and do not overlap this diff's code paths.

## Protocol changes

| Message | Change |
|---|---|
| `SessionsListRequestMessage.payload` | new optional `providers?: ExternalAgentProvider[]`, `cwd?: string` |
| `ClaudeCodeSessionInfo` | new optional `provider?`, `transcriptPath?` (populated by new walkers) |
| `ImportSessionsRequestMessage` | **new** — `{correlationId, workingDirectory, sessions: [{provider, sessionId, title, cwd?, gitBranch?, lastModified?}]}` |
| `ImportSessionsResponseMessage` | **new** — `{correlationId, ok, manifestPath?, rawCount, failures[], error?}` |

## Notes

- `.astro/imports/` is created lazily on the first `import_sessions_request`. Transcripts are **copied** (not symlinked) so the import stays valid if the user later prunes `~/.claude/projects` or `~/.codex/sessions`.
- Per-session failures are non-fatal — they accumulate in `failures[]`. The import succeeds as long as at least one transcript landed; `manifest.json` is always written.
- Provider adapters are registered in `src/session-discovery/registry.ts`; adding a fourth agent is one new file + one array entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)