### PR TITLE
feat: consume effort field in Claude and Codex adapters

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -685,8 +685,11 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     if (task.model) {
       (options as Record<string, unknown>).model = task.model;
     }
+    // effort is typed as EffortLevel in the SDK's RunOptions — cast matches the pattern
+    // used for model/systemPrompt above (Parameters<typeof query>[0]['options'] narrows too early).
     if (task.effort) {
       (options as Record<string, unknown>).effort = task.effort;
+      console.log(`[claude-sdk] Fast path: using effort=${task.effort}`);
     }
 
     // Build prompt with conversation history
@@ -1009,8 +1012,11 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     if (task.model) {
       (options as Record<string, unknown>).model = task.model;
     }
+    // effort is typed as EffortLevel in the SDK's RunOptions — cast matches the pattern
+    // used for model/systemPrompt above (Parameters<typeof query>[0]['options'] narrows too early).
     if (task.effort) {
       (options as Record<string, unknown>).effort = task.effort;
+      console.log(`[claude-sdk] Executing with effort=${task.effort}`);
     }
 
     // Load MCP servers from config if available

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -685,6 +685,9 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     if (task.model) {
       (options as Record<string, unknown>).model = task.model;
     }
+    if (task.effort) {
+      (options as Record<string, unknown>).effort = task.effort;
+    }
 
     // Build prompt with conversation history
     let effectivePrompt = task.prompt;
@@ -1005,6 +1008,9 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     // Apply explicit model selection if provided (new relay protocol field)
     if (task.model) {
       (options as Record<string, unknown>).model = task.model;
+    }
+    if (task.effort) {
+      (options as Record<string, unknown>).effort = task.effort;
     }
 
     // Load MCP servers from config if available

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -688,6 +688,9 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     // effort is typed as EffortLevel in the SDK's RunOptions — cast matches the pattern
     // used for model/systemPrompt above (Parameters<typeof query>[0]['options'] narrows too early).
     if (task.effort) {
+      if (task.effort === 'xhigh') {
+        throw new Error(`effort='xhigh' is not supported by Claude SDK (use 'low', 'medium', 'high', or 'max')`);
+      }
       (options as Record<string, unknown>).effort = task.effort;
       console.log(`[claude-sdk] Fast path: using effort=${task.effort}`);
     }
@@ -1015,6 +1018,9 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
     // effort is typed as EffortLevel in the SDK's RunOptions — cast matches the pattern
     // used for model/systemPrompt above (Parameters<typeof query>[0]['options'] narrows too early).
     if (task.effort) {
+      if (task.effort === 'xhigh') {
+        throw new Error(`effort='xhigh' is not supported by Claude SDK (use 'low', 'medium', 'high', or 'max')`);
+      }
       (options as Record<string, unknown>).effort = task.effort;
       console.log(`[claude-sdk] Executing with effort=${task.effort}`);
     }

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -557,6 +557,7 @@ export class CodexAdapter implements ProviderAdapter {
         'exec',
         '-s', 'danger-full-access',       // Full filesystem + network access
         ...(model ? ['-m', model] : []),   // Explicit model selection
+        ...(task.effort ? ['--reasoning-effort', task.effort] : []),
         ...(!isGitRepo ? ['--skip-git-repo-check'] : []),
         '--json',                         // JSONL output for structured parsing
         // Pass images via --image flag if available (Codex CLI feature)

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -553,11 +553,15 @@ export class CodexAdapter implements ProviderAdapter {
       // special character escaping issues with large plan/chat prompts.
       const useStdin = effectivePrompt.length > 4096;
 
+      if (task.effort === 'max') {
+        throw new Error(`effort='max' is not supported by Codex (use 'low', 'medium', 'high', or 'xhigh')`);
+      }
+
       const args = [
         'exec',
         '-s', 'danger-full-access',       // Full filesystem + network access
         ...(model ? ['-m', model] : []),   // Explicit model selection
-        ...(task.effort ? ['--reasoning-effort', task.effort] : []),  // reasoning effort level
+        ...(task.effort ? ['--reasoning-effort', task.effort] : []),
         ...(!isGitRepo ? ['--skip-git-repo-check'] : []),
         '--json',                         // JSONL output for structured parsing
         // Pass images via --image flag if available (Codex CLI feature)

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -557,7 +557,7 @@ export class CodexAdapter implements ProviderAdapter {
         'exec',
         '-s', 'danger-full-access',       // Full filesystem + network access
         ...(model ? ['-m', model] : []),   // Explicit model selection
-        ...(task.effort ? ['--reasoning-effort', task.effort] : []),
+        ...(task.effort ? ['--reasoning-effort', task.effort] : []),  // reasoning effort level
         ...(!isGitRepo ? ['--skip-git-repo-check'] : []),
         '--json',                         // JSONL output for structured parsing
         // Pass images via --image flag if available (Codex CLI feature)
@@ -585,7 +585,7 @@ export class CodexAdapter implements ProviderAdapter {
         return;
       }
 
-      console.log(`[codex] Task ${task.id}: spawning codex exec, promptLen=${effectivePrompt.length}, useStdin=${useStdin}, cwd=${task.workingDirectory || '(none)'}, model=${model || '(default)'}`);
+      console.log(`[codex] Task ${task.id}: spawning codex exec, promptLen=${effectivePrompt.length}, useStdin=${useStdin}, cwd=${task.workingDirectory || '(none)'}, model=${model || '(default)'}, effort=${task.effort || '(default)'}`);
 
       try {
         proc = spawn(this.codexPath!, args, {

--- a/src/providers/openclaw-adapter.ts
+++ b/src/providers/openclaw-adapter.ts
@@ -115,6 +115,12 @@ export class OpenClawAdapter implements ProviderAdapter {
     this.activeTasks++;
     const startedAt = new Date().toISOString();
 
+    if (task.effort && task.type !== 'plan') {
+      // Agent-mode WebSocket protocol (chat.send) doesn't expose per-request effort control.
+      // Effort is forwarded in the llm-task HTTP payload for plan tasks (see runLlmTask).
+      console.warn(`[openclaw] effort=${task.effort} is not supported in agent mode — ignored`);
+    }
+
     try {
       // For plan generation with outputFormat, use the llm-task HTTP endpoint
       if (task.type === 'plan' && task.outputFormat) {
@@ -718,6 +724,7 @@ export class OpenClawAdapter implements ProviderAdapter {
         prompt: effectivePrompt,
         schema: task.outputFormat!.schema,
         ...(task.model ? { model: task.model } : {}),
+        ...(task.effort ? { effort: task.effort } : {}),
       },
     });
 

--- a/src/providers/openclaw-adapter.ts
+++ b/src/providers/openclaw-adapter.ts
@@ -115,16 +115,13 @@ export class OpenClawAdapter implements ProviderAdapter {
     this.activeTasks++;
     const startedAt = new Date().toISOString();
 
-    if (task.effort && task.type !== 'plan') {
-      // Agent-mode WebSocket protocol (chat.send) doesn't expose per-request effort control.
-      // Effort is forwarded in the llm-task HTTP payload for plan tasks (see runLlmTask).
-      console.warn(`[openclaw] effort=${task.effort} is not supported in agent mode — ignored`);
-    }
-
     try {
       // For plan generation with outputFormat, use the llm-task HTTP endpoint
       if (task.type === 'plan' && task.outputFormat) {
         try {
+          if (task.effort) {
+            console.log(`[openclaw] Plan task: forwarding effort=${task.effort} in llm-task payload`);
+          }
           const result = await this.runLlmTask(task, stream, signal);
           return {
             taskId: task.id,
@@ -139,6 +136,11 @@ export class OpenClawAdapter implements ProviderAdapter {
           // Fall through to agent mode
           console.warn('[openclaw] llm-task failed, falling back to agent mode:', err);
         }
+      }
+
+      // Agent-mode WebSocket protocol (chat.send) doesn't expose per-request effort control.
+      if (task.effort) {
+        console.warn(`[openclaw] effort=${task.effort} is not supported in agent mode — ignored`);
       }
 
       stream.status('running', 0, 'Connecting to OpenClaw gateway');

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -441,6 +441,10 @@ export class OpenCodeAdapter implements ProviderAdapter {
       effectivePrompt = `${conversationContext}\n\nHuman: ${effectivePrompt}`;
     }
 
+    if (task.effort) {
+      console.warn(`[opencode] effort=${task.effort} is not supported by the OpenCode CLI — ignored`);
+    }
+
     const args = [
       'run',
       '--print',

--- a/src/providers/pi-adapter.ts
+++ b/src/providers/pi-adapter.ts
@@ -228,6 +228,10 @@ export class PiAdapter implements ProviderAdapter {
     const startedAt = new Date().toISOString();
     this.activeTasks++;
 
+    if (task.effort) {
+      console.warn(`[pi] effort=${task.effort} is not supported by the Pi SDK — ignored`);
+    }
+
     try {
       const { createAgentSession, SessionManager } = await import('@mariozechner/pi-coding-agent');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,8 +149,10 @@ export interface Task {
 
   /**
    * Reasoning/thinking effort level.
-   * - Claude: 'low' | 'medium' | 'high' | 'max' (max = Opus only)
-   * - Codex: 'low' | 'medium' | 'high' | 'xhigh' (xhigh not available on small models)
+   * - claude-sdk: 'low' | 'medium' | 'high' | 'max' (max = Opus only). Maps to SDK's EffortLevel.
+   * - codex: 'low' | 'medium' | 'high' | 'xhigh' (xhigh not available on small/mini models). Maps to --reasoning-effort CLI flag.
+   * - openclaw (plan/llm-task mode): forwarded in HTTP payload; gateway ignores unknown fields.
+   * - openclaw (agent mode), opencode, pi: not supported — a warning is logged and the value is ignored.
    */
   effort?: 'low' | 'medium' | 'high' | 'max' | 'xhigh';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,13 @@ export interface Task {
   /** Explicit model selection — e.g. 'claude-sonnet-4-20250514' */
   model?: string;
 
+  /**
+   * Reasoning/thinking effort level.
+   * - Claude: 'low' | 'medium' | 'high' | 'max' (max = Opus only)
+   * - Codex: 'low' | 'medium' | 'high' | 'xhigh' (xhigh not available on small models)
+   */
+  effort?: 'low' | 'medium' | 'high' | 'max' | 'xhigh';
+
   /** How results should be delivered: 'pr' | 'push' | 'branch' | 'copy' | 'direct' */
   deliveryMode?: 'pr' | 'push' | 'branch' | 'copy' | 'direct';
 


### PR DESCRIPTION
## Summary

- **`src/types.ts`**: Add `effort?: 'low' | 'medium' | 'high' | 'max' | 'xhigh'` to `Task` interface
- **`claude-sdk-adapter.ts`**: Pass `task.effort` as `options.effort` in both the main execution path and the summarize path
- **`codex-adapter.ts`**: Pass `--reasoning-effort <level>` flag to `codex exec` when effort is set

## Context

The Astro platform now lets users select a reasoning effort level from the sidebar (hovering on the small/medium/large model bubble shows a dropdown). The selection is persisted in settings and forwarded through the dispatch pipeline to the relay. This PR makes the agent runner actually use the value.

Provider-specific behavior:
- **Claude** (`claude-sdk`): `effort` maps to the SDK's adaptive thinking effort (`low`/`medium`/`high`/`max`). `max` is only shown for Opus.
- **Codex**: `effort` maps to `--reasoning-effort` CLI flag (`low`/`medium`/`high`/`xhigh`). `xhigh` is only shown for medium/large model tiers.

## Test plan

- [ ] Dispatch a task with effort=high — verify Claude runs with extended thinking
- [ ] Dispatch a Codex task with effort=xhigh — verify `--reasoning-effort xhigh` appears in the spawned process args
- [ ] Dispatch without setting effort — verify both adapters work unchanged (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)