### PR TITLE
chore: bump @astroanywhere/cli dep to ^0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@astroanywhere/agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astroanywhere/agent",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "BSL-1.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
-        "@astroanywhere/cli": "^0.5.1",
+        "@astroanywhere/cli": "^0.6.1",
         "@mariozechner/pi-coding-agent": "^0.60.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "chalk": "^5.3.0",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@astroanywhere/cli": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@astroanywhere/cli/-/cli-0.5.1.tgz",
-      "integrity": "sha512-N7RaU7HXVf7YDr9DozBqwg3c76ptDzpj37S2aqsgekD2JEiJNoX8w8rJCRo/vP5pf86aI3rSPNqDRxsB/hkjjA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@astroanywhere/cli/-/cli-0.6.1.tgz",
+      "integrity": "sha512-jOKkQA4Hie70FrZ0xEvlXB946q0eo0QbXkbX99D/1FI4yI8HrMe3KyW68zqirkGNhlM/aqJMaF2RgeAhaSaH2w==",
       "license": "BSL-1.1",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/astro-anywhere/astro-agent#readme",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.116",
-    "@astroanywhere/cli": "^0.5.1",
+    "@astroanywhere/cli": "^0.6.1",
     "@mariozechner/pi-coding-agent": "^0.60.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
## Summary

- Bumps `@astroanywhere/cli` from `^0.5.1` to `^0.6.1` so the agent bundles the new CLI that supports the reference inbox (`ref import --accept` / `--project` flags).

The previous range `^0.5.1` has a semver ceiling at `<0.6.0` and would silently continue using the old CLI binary even after `@astroanywhere/cli@0.6.1` was published.

## Test plan

- [ ] `npm install` resolves `@astroanywhere/cli@0.6.1`
- [ ] `npm run build` passes
- [ ] After agent release: `npx @astroanywhere/agent@latest` bundles CLI 0.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)