### PR TITLE
Release: merge dev → main (v0.7.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@astroanywhere/agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astroanywhere/agent",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "BSL-1.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
-        "@astroanywhere/cli": "^0.5.1",
+        "@astroanywhere/cli": "^0.6.1",
         "@mariozechner/pi-coding-agent": "^0.60.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "chalk": "^5.3.0",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@astroanywhere/cli": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@astroanywhere/cli/-/cli-0.5.1.tgz",
-      "integrity": "sha512-N7RaU7HXVf7YDr9DozBqwg3c76ptDzpj37S2aqsgekD2JEiJNoX8w8rJCRo/vP5pf86aI3rSPNqDRxsB/hkjjA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@astroanywhere/cli/-/cli-0.6.1.tgz",
+      "integrity": "sha512-jOKkQA4Hie70FrZ0xEvlXB946q0eo0QbXkbX99D/1FI4yI8HrMe3KyW68zqirkGNhlM/aqJMaF2RgeAhaSaH2w==",
       "license": "BSL-1.1",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/astro-anywhere/astro-agent#readme",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.116",
-    "@astroanywhere/cli": "^0.5.1",
+    "@astroanywhere/cli": "^0.6.1",
     "@mariozechner/pi-coding-agent": "^0.60.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
## Summary

Release merge: 2 changes from `dev` into `main` for publishing as v0.7.1.

### What changed

- **chore**: bump `@astroanywhere/cli` dep from `^0.5.1` to `^0.6.1` so the agent bundles the CLI with reference inbox support (`ref import --accept` / `--project` flags)

## Release Flow

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#dbeafe', 'primaryBorderColor': '#93c5fd', 'primaryTextColor': '#1e293b', 'lineColor': '#64748b', 'textColor': '#334155', 'fontSize': '14px'}}}%%
flowchart LR
    classDef blue fill:#dbeafe,stroke:#93c5fd,color:#1e293b
    classDef green fill:#dcfce7,stroke:#86efac,color:#1e293b
    classDef amber fill:#fef3c7,stroke:#fcd34b,color:#1e293b
    A["dev branch"]:::blue --> B["merge PR"]:::amber
    B --> C["main branch"]:::green
    C --> D["v0.7.1 tag"]:::blue
    D --> E["GitHub Release"]:::blue
    E --> F["NPM publish"]:::green
```

## Test Plan

- [ ] `npm run build` passes on main after merge
- [ ] Release Action publishes `@astroanywhere/agent@0.7.1` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)