### PR TITLE
fix: enforce Bedrock env vars in HIPAA mode

### DIFF
--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -38,6 +38,13 @@ function resolveClaudeExecutable(): string | undefined {
 
 /** Cached result of resolveClaudeExecutable() — computed once at module load. */
 const claudeExecutablePath = resolveClaudeExecutable();
+
+import { assertHipaaBedrockEnv } from './hipaa-startup-check.js';
+
+// Fail-closed: if HIPAA mode is enabled but Bedrock env vars are misconfigured,
+// abort module load so the agent-runner never starts in a non-compliant state.
+assertHipaaBedrockEnv();
+
 import type { Task, TaskResult, TaskArtifact, ExecutionSummary, HpcCapability } from '../types.js';
 import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';
 import { type ProviderAdapter, type NormalizedTask, type TaskOutputStream, type ProviderStatus, SUMMARY_PROMPT, SUMMARY_TIMEOUT_MS, parseSummaryResponse, getAugmentedPath } from './base-adapter.js';

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -11,6 +11,14 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 
+import { assertHipaaBedrockEnv } from './hipaa-startup-check.js';
+
+// Fail-closed: if HIPAA mode is enabled but Bedrock env vars are misconfigured,
+// abort module load before any other side effects (including `which claude`
+// subprocess + stdout logs) so the agent-runner never starts in a
+// non-compliant state.
+assertHipaaBedrockEnv();
+
 /**
  * Resolve the path to the Claude Code executable.
  *
@@ -38,12 +46,6 @@ function resolveClaudeExecutable(): string | undefined {
 
 /** Cached result of resolveClaudeExecutable() — computed once at module load. */
 const claudeExecutablePath = resolveClaudeExecutable();
-
-import { assertHipaaBedrockEnv } from './hipaa-startup-check.js';
-
-// Fail-closed: if HIPAA mode is enabled but Bedrock env vars are misconfigured,
-// abort module load so the agent-runner never starts in a non-compliant state.
-assertHipaaBedrockEnv();
 
 import type { Task, TaskResult, TaskArtifact, ExecutionSummary, HpcCapability } from '../types.js';
 import { writeImagesToDir, cleanupImages } from '../lib/image-utils.js';

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -6,18 +6,15 @@
  * Supports mid-execution steering via Query.streamInput().
  */
 
+// HIPAA preflight MUST be imported before the Claude SDK. ES modules evaluate
+// static imports in source order, so this import runs `assertHipaaBedrockEnv()`
+// and throws (when misconfigured) BEFORE `@anthropic-ai/claude-agent-sdk` is
+// loaded. Do not reorder — this is the fail-closed guarantee.
+import './hipaa-preflight.js';
 import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
-
-import { assertHipaaBedrockEnv } from './hipaa-startup-check.js';
-
-// Fail-closed: if HIPAA mode is enabled but Bedrock env vars are misconfigured,
-// abort module load before any other side effects (including `which claude`
-// subprocess + stdout logs) so the agent-runner never starts in a
-// non-compliant state.
-assertHipaaBedrockEnv();
 
 /**
  * Resolve the path to the Claude Code executable.

--- a/src/providers/hipaa-preflight.ts
+++ b/src/providers/hipaa-preflight.ts
@@ -1,0 +1,20 @@
+/**
+ * HIPAA preflight.
+ *
+ * This module's SOLE purpose is to run `assertHipaaBedrockEnv()` at top level
+ * so that importing it BEFORE `@anthropic-ai/claude-agent-sdk` (or any module
+ * that statically imports the SDK, such as `claude-sdk-adapter.ts`) guarantees
+ * the HIPAA check fires first.
+ *
+ * ES modules evaluate static imports in source order, so any module that
+ * lists this import before other SDK-touching imports is provably fail-closed:
+ * if the environment is misconfigured under `ASTRO_HIPAA_MODE=true`, this
+ * module throws during its own evaluation and no downstream module (including
+ * the Claude SDK) gets a chance to load.
+ *
+ * Do not add any other exports or side effects to this file — keeping it
+ * minimal is load-bearing.
+ */
+import { assertHipaaBedrockEnv } from './hipaa-startup-check.js';
+
+assertHipaaBedrockEnv();

--- a/src/providers/hipaa-startup-check.ts
+++ b/src/providers/hipaa-startup-check.ts
@@ -6,6 +6,11 @@
  * correct env vars are set; we enforce those here and fail closed at boot if
  * any are missing or if a direct-Anthropic API key is present.
  *
+ * Scope: the Claude SDK is the only provider that natively supports Bedrock,
+ * so it is the only provider this check gates. Codex/OpenClaw/OpenCode/Pi
+ * call non-Bedrock services and are intentionally out of HIPAA scope — they
+ * are expected to be disabled by deployment configuration in HIPAA mode.
+ *
  * See Phase 3 of the HIPAA compliance plan.
  */
 export function assertHipaaBedrockEnv(env: NodeJS.ProcessEnv = process.env): void {
@@ -38,5 +43,10 @@ export function assertHipaaBedrockEnv(env: NodeJS.ProcessEnv = process.env): voi
     );
   }
 
-  console.log('[claude-sdk] HIPAA mode: Bedrock env vars verified');
+  // Success path: stay silent by default to avoid broadcasting the HIPAA
+  // posture of the deployment in logs. Gate on DEBUG/VERBOSE for operators
+  // who want explicit confirmation.
+  if (process.env.DEBUG || process.env.VERBOSE) {
+    console.log('[claude-sdk] HIPAA mode: Bedrock env vars verified');
+  }
 }

--- a/src/providers/hipaa-startup-check.ts
+++ b/src/providers/hipaa-startup-check.ts
@@ -12,7 +12,15 @@ export function assertHipaaBedrockEnv(env: NodeJS.ProcessEnv = process.env): voi
   if (env.ASTRO_HIPAA_MODE !== 'true') return;
 
   const missing: string[] = [];
-  if (env.CLAUDE_CODE_USE_BEDROCK !== '1') missing.push('CLAUDE_CODE_USE_BEDROCK=1');
+  if (env.CLAUDE_CODE_USE_BEDROCK !== '1') {
+    // The Claude SDK only accepts the exact string "1" (not "true"/"yes").
+    // Surface the actual value so operators do not have to guess why a
+    // truthy-looking setting was rejected.
+    const hint = env.CLAUDE_CODE_USE_BEDROCK
+      ? ` (got "${env.CLAUDE_CODE_USE_BEDROCK}", must be exactly "1")`
+      : '';
+    missing.push(`CLAUDE_CODE_USE_BEDROCK=1${hint}`);
+  }
   if (!env.AWS_REGION) missing.push('AWS_REGION');
   if (!env.ANTHROPIC_MODEL) missing.push('ANTHROPIC_MODEL (must be Bedrock model id)');
 

--- a/src/providers/hipaa-startup-check.ts
+++ b/src/providers/hipaa-startup-check.ts
@@ -15,13 +15,18 @@ export function assertHipaaBedrockEnv(env: NodeJS.ProcessEnv = process.env): voi
   if (env.CLAUDE_CODE_USE_BEDROCK !== '1') missing.push('CLAUDE_CODE_USE_BEDROCK=1');
   if (!env.AWS_REGION) missing.push('AWS_REGION');
   if (!env.ANTHROPIC_MODEL) missing.push('ANTHROPIC_MODEL (must be Bedrock model id)');
+
+  const forbidden: string[] = [];
   if (env.ANTHROPIC_API_KEY) {
-    missing.push('(forbidden) ANTHROPIC_API_KEY must not be set in HIPAA mode');
+    forbidden.push('ANTHROPIC_API_KEY must not be set in HIPAA mode');
   }
 
-  if (missing.length > 0) {
+  if (missing.length > 0 || forbidden.length > 0) {
+    const parts: string[] = [];
+    if (missing.length > 0) parts.push(`missing required: ${missing.join(', ')}`);
+    if (forbidden.length > 0) parts.push(`forbidden present: ${forbidden.join(', ')}`);
     throw new Error(
-      `HIPAA mode requires Bedrock routing. Problems: ${missing.join(', ')}`,
+      `HIPAA mode requires Bedrock routing. ${parts.join('; ')}`,
     );
   }
 

--- a/src/providers/hipaa-startup-check.ts
+++ b/src/providers/hipaa-startup-check.ts
@@ -1,0 +1,29 @@
+/**
+ * HIPAA mode startup check.
+ *
+ * When `ASTRO_HIPAA_MODE=true`, Astro must route all AI calls through AWS
+ * Bedrock (under the AWS BAA). Claude Code natively supports Bedrock when the
+ * correct env vars are set; we enforce those here and fail closed at boot if
+ * any are missing or if a direct-Anthropic API key is present.
+ *
+ * See Phase 3 of the HIPAA compliance plan.
+ */
+export function assertHipaaBedrockEnv(env: NodeJS.ProcessEnv = process.env): void {
+  if (env.ASTRO_HIPAA_MODE !== 'true') return;
+
+  const missing: string[] = [];
+  if (env.CLAUDE_CODE_USE_BEDROCK !== '1') missing.push('CLAUDE_CODE_USE_BEDROCK=1');
+  if (!env.AWS_REGION) missing.push('AWS_REGION');
+  if (!env.ANTHROPIC_MODEL) missing.push('ANTHROPIC_MODEL (must be Bedrock model id)');
+  if (env.ANTHROPIC_API_KEY) {
+    missing.push('(forbidden) ANTHROPIC_API_KEY must not be set in HIPAA mode');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `HIPAA mode requires Bedrock routing. Problems: ${missing.join(', ')}`,
+    );
+  }
+
+  console.log('[claude-sdk] HIPAA mode: Bedrock env vars verified');
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,12 @@
  * Provider adapters index
  */
 
+// Defense-in-depth: run HIPAA preflight before any adapter that touches the
+// Claude SDK is re-exported or instantiated. `claude-sdk-adapter.ts` imports
+// the preflight first too; listing it here as well means consumers that reach
+// the SDK via this index still get fail-closed behavior in source order.
+import './hipaa-preflight.js';
+
 export type { ProviderAdapter, TaskOutputStream, ProviderStatus } from './base-adapter.js';
 export { ClaudeSdkAdapter } from './claude-sdk-adapter.js';
 export { CodexAdapter } from './codex-adapter.js';

--- a/tests/hipaa-startup-check.test.ts
+++ b/tests/hipaa-startup-check.test.ts
@@ -49,13 +49,50 @@ describe('assertHipaaBedrockEnv', () => {
         ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
         ANTHROPIC_API_KEY: 'sk-ant-should-not-be-here',
       }),
-    ).toThrow(/ANTHROPIC_API_KEY must not be set/);
+    ).toThrow(/forbidden present:.*ANTHROPIC_API_KEY must not be set/);
   });
 
   it('aggregates multiple missing requirements in the error message', () => {
     expect(() =>
       assertHipaaBedrockEnv({ ASTRO_HIPAA_MODE: 'true' }),
-    ).toThrow(/CLAUDE_CODE_USE_BEDROCK=1.*AWS_REGION.*ANTHROPIC_MODEL/s);
+    ).toThrow(/missing required:.*CLAUDE_CODE_USE_BEDROCK=1.*AWS_REGION.*ANTHROPIC_MODEL/s);
+  });
+
+  it('separates missing and forbidden categories in the error message', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        ANTHROPIC_API_KEY: 'sk-ant-should-not-be-here',
+      }),
+    ).toThrow(/missing required:.*forbidden present:/s);
+  });
+
+  it('does not include forbidden category when no forbidden vars are present', () => {
+    try {
+      assertHipaaBedrockEnv({ ASTRO_HIPAA_MODE: 'true' });
+    } catch (err) {
+      expect((err as Error).message).toMatch(/missing required:/);
+      expect((err as Error).message).not.toMatch(/forbidden present:/);
+      return;
+    }
+    throw new Error('expected assertHipaaBedrockEnv to throw');
+  });
+
+  it('does not include missing category when only forbidden vars are the problem', () => {
+    try {
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        ANTHROPIC_API_KEY: 'sk-ant-should-not-be-here',
+      });
+    } catch (err) {
+      expect((err as Error).message).toMatch(/forbidden present:/);
+      expect((err as Error).message).not.toMatch(/missing required:/);
+      return;
+    }
+    throw new Error('expected assertHipaaBedrockEnv to throw');
   });
 
   it('does not throw when all Bedrock env vars are correctly configured', () => {

--- a/tests/hipaa-startup-check.test.ts
+++ b/tests/hipaa-startup-check.test.ts
@@ -95,6 +95,43 @@ describe('assertHipaaBedrockEnv', () => {
     throw new Error('expected assertHipaaBedrockEnv to throw');
   });
 
+  it('reports the actual invalid value when CLAUDE_CODE_USE_BEDROCK is a truthy non-"1" string', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: 'true',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      }),
+    ).toThrow(/CLAUDE_CODE_USE_BEDROCK=1 \(got "true", must be exactly "1"\)/);
+  });
+
+  it('omits the hint when CLAUDE_CODE_USE_BEDROCK is unset', () => {
+    try {
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      });
+    } catch (err) {
+      expect((err as Error).message).toMatch(/CLAUDE_CODE_USE_BEDROCK=1(?!\s*\()/);
+      expect((err as Error).message).not.toMatch(/got "/);
+      return;
+    }
+    throw new Error('expected assertHipaaBedrockEnv to throw');
+  });
+
+  it('reports the actual invalid value for other non-"1" strings like "yes"', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: 'yes',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      }),
+    ).toThrow(/got "yes", must be exactly "1"/);
+  });
+
   it('does not throw when all Bedrock env vars are correctly configured', () => {
     expect(() =>
       assertHipaaBedrockEnv({

--- a/tests/hipaa-startup-check.test.ts
+++ b/tests/hipaa-startup-check.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { assertHipaaBedrockEnv } from '../src/providers/hipaa-startup-check.js';
+
+describe('assertHipaaBedrockEnv', () => {
+  it('is a no-op when ASTRO_HIPAA_MODE is not set', () => {
+    expect(() => assertHipaaBedrockEnv({})).not.toThrow();
+  });
+
+  it('is a no-op when ASTRO_HIPAA_MODE is not "true"', () => {
+    expect(() => assertHipaaBedrockEnv({ ASTRO_HIPAA_MODE: 'false' })).not.toThrow();
+  });
+
+  it('throws when HIPAA mode is on but CLAUDE_CODE_USE_BEDROCK is missing', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      }),
+    ).toThrow(/CLAUDE_CODE_USE_BEDROCK=1/);
+  });
+
+  it('throws when AWS_REGION is missing', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      }),
+    ).toThrow(/AWS_REGION/);
+  });
+
+  it('throws when ANTHROPIC_MODEL is missing', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        AWS_REGION: 'us-east-1',
+      }),
+    ).toThrow(/ANTHROPIC_MODEL/);
+  });
+
+  it('throws when ANTHROPIC_API_KEY is present (forbidden in HIPAA mode)', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        ANTHROPIC_API_KEY: 'sk-ant-should-not-be-here',
+      }),
+    ).toThrow(/ANTHROPIC_API_KEY must not be set/);
+  });
+
+  it('aggregates multiple missing requirements in the error message', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({ ASTRO_HIPAA_MODE: 'true' }),
+    ).toThrow(/CLAUDE_CODE_USE_BEDROCK=1.*AWS_REGION.*ANTHROPIC_MODEL/s);
+  });
+
+  it('does not throw when all Bedrock env vars are correctly configured', () => {
+    expect(() =>
+      assertHipaaBedrockEnv({
+        ASTRO_HIPAA_MODE: 'true',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        AWS_REGION: 'us-east-1',
+        ANTHROPIC_MODEL: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the Astro HIPAA compliance plan. Adds a fail-closed startup check to `claude-sdk-adapter.ts` that refuses to run when `ASTRO_HIPAA_MODE=true` unless the Claude Code CLI is configured to route through AWS Bedrock (under the AWS BAA).

## Why

HIPAA deployments of Astro must keep all PHI-bearing AI calls inside the AWS BAA boundary. Claude Code natively supports Bedrock when `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, and `ANTHROPIC_MODEL=<bedrock-model-id>` are set on the agent-runner machine — no in-adapter abstraction is needed. We only need to enforce those env vars at boot so a misconfigured HIPAA runner cannot silently fall back to `api.anthropic.com`.

## What changes

- New `src/providers/hipaa-startup-check.ts` — pure function `assertHipaaBedrockEnv(env)` that checks:
  - `CLAUDE_CODE_USE_BEDROCK === '1'`
  - `AWS_REGION` set
  - `ANTHROPIC_MODEL` set (must be a Bedrock model id)
  - `ANTHROPIC_API_KEY` NOT set (forbidden — would bypass Bedrock routing)
- `src/providers/claude-sdk-adapter.ts` — invokes the check once at module load. Throws a descriptive error listing every problem if HIPAA mode is on but config is wrong. No-op outside HIPAA mode.
- `tests/hipaa-startup-check.test.ts` — 8 unit tests covering no-op paths, each missing-var path, the forbidden-API-key path, and the happy path.

## Test plan

- [x] `npm run build` passes cleanly
- [x] `npx vitest run tests/hipaa-startup-check.test.ts` — 8/8 passing
- [ ] Manual smoke: boot agent-runner with `ASTRO_HIPAA_MODE=true` and missing env vars, confirm it aborts
- [ ] Manual smoke: boot with full Bedrock env vars, confirm it starts and routes outbound to `bedrock-runtime.*.amazonaws.com`

## Follow-up

This is the agent-runner piece only. After merge to `dev` and then `main`, a separate astro-repo PR will bump the submodule pointer and add the server-side HIPAA mode scaffolding (Phases 1–2).