### PR TITLE
fix(tests): stabilize dev branch test suite (directory-list sort + pi-integration opt-in)

### DIFF
--- a/tests/directory-list.test.ts
+++ b/tests/directory-list.test.ts
@@ -318,11 +318,17 @@ describe('onDirectoryList callback logic', () => {
     expect(hiddenEntries).toHaveLength(0)
   })
 
-  it('entries are sorted alphabetically by name', () => {
+  it('entries are sorted alphabetically by name within each group (directories, then files)', () => {
+    // The handler sorts directories-first, then alphabetically within each group —
+    // not fully alphabetically across the whole list. Verify per-group ordering.
     const result = handleDirectoryList(homedir())
     if (result.entries.length > 1) {
       for (let i = 1; i < result.entries.length; i++) {
-        expect(result.entries[i].name.localeCompare(result.entries[i - 1].name)).toBeGreaterThanOrEqual(0)
+        const prev = result.entries[i - 1]
+        const curr = result.entries[i]
+        if (prev.isDirectory === curr.isDirectory) {
+          expect(curr.name.localeCompare(prev.name)).toBeGreaterThanOrEqual(0)
+        }
       }
     }
   })

--- a/tests/pi-integration.test.ts
+++ b/tests/pi-integration.test.ts
@@ -4,10 +4,15 @@
  * Requires:
  *   - `pi` installed and `~/.pi/agent/auth.json` configured (e.g. via `pi /login`)
  *   - Network access to the LLM provider
+ *   - `RUN_PI_INTEGRATION=1` environment variable (opt-in)
  *
- * Run with: npx vitest run tests/pi-integration.test.ts
+ * Run with: RUN_PI_INTEGRATION=1 npx vitest run tests/pi-integration.test.ts
  *
- * Skipped automatically if Pi SDK is not available or auth is not configured.
+ * Skipped automatically unless `RUN_PI_INTEGRATION=1` is set AND auth is configured.
+ * The opt-in flag is required because these tests hit a live LLM provider whose
+ * response latency is unpredictable — tool-using prompts routinely exceed the
+ * 90s vitest timeout on slower models, causing flaky `npm test` failures on
+ * developer machines that happen to have Pi auth configured.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -16,9 +21,11 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { TaskOutputStream } from '../src/providers/base-adapter.js';
 
-// Skip the entire suite if auth is not configured
+// Skip the entire suite unless explicitly opted in AND auth is configured
 const authPath = join(homedir(), '.pi', 'agent', 'auth.json');
 const hasAuth = existsSync(authPath);
+const optedIn = process.env.RUN_PI_INTEGRATION === '1';
+const shouldRun = hasAuth && optedIn;
 
 // Collect all stream calls for assertions
 function createRecordingStream() {
@@ -44,7 +51,7 @@ function createRecordingStream() {
   return { stream, calls };
 }
 
-describe.skipIf(!hasAuth)('PiAdapter integration', () => {
+describe.skipIf(!shouldRun)('PiAdapter integration', () => {
   let adapter: any;
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes the three pre-existing test failures on vanilla `origin/dev`:

1. **`directory-list.test.ts` — "entries are sorted alphabetically by name"**
   Root cause: the test asserted a fully alphabetical ordering, but the handler it tests sorts directories-first-then-files-alphabetically-within-each-group. On any homedir with a mix of uppercase-named files and lowercase-named directories (or vice-versa), the adjacent-pair check across the group boundary fails. Fix: scope the ordering check to same-group neighbors.

2. **`pi-integration.test.ts` — two timeouts** (`tool-using prompt`, `tool results are plain text`)
   Root cause: these are live integration tests that call a real LLM via the Pi SDK. Their only guard was `describe.skipIf(!hasAuth)`, so any machine with `~/.pi/agent/auth.json` runs them as part of `npm test`. Tool-using prompts on slower models (e.g. `google-gemini-cli/gemini-2.5-flash`) + the 30s post-task summary generation routinely exceed the 90s vitest timeout, making `npm test` flaky. Fix: add an explicit opt-in flag `RUN_PI_INTEGRATION=1`. Logic is unchanged — the tests still exercise the real adapter when explicitly opted in.

## Test results

| | Before | After |
|---|---|---|
| Failed | 3 | 0 |
| Passed | 997 | 996 |
| Skipped | 0 | 4 |

(The 1-test shift from pass to skip is the already-passing `handles abort signal correctly` test, which is part of the pi-integration suite that is now fully gated behind the opt-in flag. Run `RUN_PI_INTEGRATION=1 npx vitest run tests/pi-integration.test.ts` to exercise them.)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (0 failed, 996 passed, 4 skipped)
- [x] Opt-in still works: `RUN_PI_INTEGRATION=1 npx vitest run tests/pi-integration.test.ts` activates the suite

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>