### PR TITLE
fix: fall back to fresh execution when session resume returns empty

### DIFF
--- a/src/lib/task-executor.ts
+++ b/src/lib/task-executor.ts
@@ -1226,7 +1226,7 @@ export class TaskExecutor {
             stream,
             abortController.signal,
           );
-          if (resumeResult.success) {
+          if (resumeResult.success && resumeResult.output.trim()) {
             result = {
               taskId: taskWithWorkspace.id,
               status: 'completed',
@@ -1234,6 +1234,12 @@ export class TaskExecutor {
               startedAt: resumeStartedAt,
               completedAt: new Date().toISOString(),
             };
+          } else if (resumeResult.success && !resumeResult.output.trim()) {
+            // Resume reported success but produced no output — the session was
+            // likely expired or already completed. Fall back to fresh execution.
+            console.warn(`[executor] Task ${task.id}: resume returned success but empty output, falling back to fresh execution`);
+            stream.operational?.('Session expired, starting fresh session', 'astro');
+            result = await adapter.execute(taskWithWorkspace, stream, abortController.signal);
           } else {
             // Resume resolved but failed (e.g. Codex session expired, CLI error) —
             // fall back to fresh execution. Codex/OpenCode adapters resolve with

--- a/src/providers/claude-sdk-adapter.ts
+++ b/src/providers/claude-sdk-adapter.ts
@@ -431,11 +431,16 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
       let success = true;
       let errorMessage: string | undefined;
       let newSessionId = sessionId;
+      // Track whether we received a system.init — if the SDK skips straight to
+      // result.success without init, the session was already complete and the
+      // new prompt was never processed.
+      let receivedInit = false;
       // Map tool_use_id → tool name for matching results back to uses
       const resumeToolUseNames = new Map<string, string>();
 
       for await (const msg of gen) {
         if (msg.type === 'system' && msg.subtype === 'init') {
+          receivedInit = true;
           newSessionId = (msg as unknown as Record<string, unknown>).session_id as string ?? sessionId;
           this.activeQueries.set(taskId, { query: gen, sessionId: newSessionId, workingDirectory });
           stream.sessionInit(newSessionId, msg.model);
@@ -479,6 +484,15 @@ export class ClaudeSdkAdapter implements ProviderAdapter {
           }
           break;
         }
+      }
+
+      // Detect empty resume: the SDK returned result.success without ever
+      // sending system.init or any assistant content. This happens when
+      // the session is already in a terminal state (completed, expired).
+      // Report as failure so the caller falls back to fresh execution.
+      if (success && !receivedInit && !output) {
+        console.warn(`[claude-sdk] Task ${taskId}: resume returned success but no init/output — session ${sessionId} is likely expired or already completed`);
+        return { success: false, output: '', error: 'Session expired — no response from resumed session' };
       }
 
       // Preserve context after resume completes


### PR DESCRIPTION
## Summary

- Fixes silent "no response" in project chat when resuming a completed/expired Claude SDK session
- Claude SDK's `query({ resume })` returns `result.success` instantly with empty output when the session is terminal — the adapter now detects this (missing `system.init`) and returns `success: false`
- Task executor adds a belt-and-suspenders check: `success && empty output` triggers fresh execution fallback

## Evidence

Agent runner logs showed 12 consecutive dispatches with `resumeSessionId=03e99d0e-...`, each completing instantly with zero text:
```
resuming session 03e99d0e-... (hasMessages=false)...
completed with status=completed     ← instant, no [claude-sdk] output
```

## Test plan

- [x] `npm run build` passes
- [x] `tests/silent-task-failures.test.ts` — 22 tests pass (most relevant to this change)
- [x] Pre-existing test failures in `workdir-safety.test.ts` are unrelated (same on `dev`)
- [ ] Manual: open project chat, send message, get response, send follow-up → should get response instead of silence

Fixes fuxialexander/astro#1329