### PR TITLE
feat(ssh-install): direct SCP of bundles, no remote npm or PATH dependence

### DIFF
--- a/src/commands/__tests__/ssh-install.test.ts
+++ b/src/commands/__tests__/ssh-install.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the ssh-install command's NDJSON contract.
  *
- * We don't exercise real SSH here — `packAndInstall` and `startRemoteAgents`
+ * We don't exercise real SSH here — `directInstall` and `startRemoteAgents`
  * are mocked so we can verify the orchestration: emitted event sequence,
  * step classification, error handling, and exit codes.
  */
@@ -14,14 +14,14 @@ vi.mock('../../lib/ssh-discovery.js', () => ({
   ]),
 }));
 
-const packAndInstall = vi.fn();
+const directInstall = vi.fn();
 const startRemoteAgents = vi.fn();
 const buildSshArgs = vi.fn(
   (host: { name: string }, command: string) => ['-o', 'BatchMode=yes', host.name, command],
 );
 
 vi.mock('../../lib/ssh-installer.js', () => ({
-  packAndInstall: (...args: Parameters<typeof packAndInstall>) => packAndInstall(...args),
+  directInstall: (...args: Parameters<typeof directInstall>) => directInstall(...args),
   startRemoteAgents: (...args: Parameters<typeof startRemoteAgents>) => startRemoteAgents(...args),
   buildSshArgs: (...args: Parameters<typeof buildSshArgs>) => buildSshArgs(...args),
 }));
@@ -81,7 +81,7 @@ function captureStdout(): { lines: () => CapturedEvent[]; restore: () => void } 
 
 describe('sshInstallCommand', () => {
   beforeEach(() => {
-    packAndInstall.mockReset();
+    directInstall.mockReset();
     startRemoteAgents.mockReset();
     execFileImpl.mockReset();
     execFileImpl.mockImplementation((_cmd, _args, _opts, cb) => {
@@ -97,11 +97,12 @@ describe('sshInstallCommand', () => {
   });
 
   it('emits step → done events on a successful install', async () => {
-    packAndInstall.mockImplementation(async (_opts, onProgress) => {
-      onProgress?.('Packing agent-runner...');
-      onProgress?.('Copying to demo...');
-      onProgress?.('Installing on demo...');
-      onProgress?.('Configuring tokens on demo...');
+    directInstall.mockImplementation(async (_opts, onProgress) => {
+      onProgress?.('Locating node on demo...');
+      onProgress?.('Preparing ~/.astro on demo...');
+      onProgress?.('Uploading bundles to demo...');
+      onProgress?.('Installing wrappers on demo...');
+      onProgress?.('Configuring demo...');
     });
     startRemoteAgents.mockImplementation(async (_hosts, _opts, onProgress) => {
       onProgress?.('demo', 'Stopping existing agent (if any)...');
@@ -121,7 +122,7 @@ describe('sshInstallCommand', () => {
     const stepNames = events.filter((e) => e.event === 'step').map((e) => e.name);
 
     expect(stepNames).toEqual(
-      expect.arrayContaining(['preflight', 'pack', 'upload', 'install', 'configure', 'stop-existing', 'start', 'verify']),
+      expect.arrayContaining(['preflight', 'detect-node', 'prepare', 'upload', 'install', 'configure', 'stop-existing', 'start', 'verify']),
     );
     const last = events[events.length - 1];
     expect(last.event).toBe('done');
@@ -146,8 +147,8 @@ describe('sshInstallCommand', () => {
     expect(String(thrown)).toContain('__exit:1');
   });
 
-  it('emits {event:"error", code:"install-failed"} when packAndInstall throws', async () => {
-    packAndInstall.mockRejectedValue(new Error('scp: permission denied'));
+  it('emits {event:"error", code:"install-failed"} when directInstall throws', async () => {
+    directInstall.mockRejectedValue(new Error('scp: permission denied'));
 
     const cap = captureStdout();
     let thrown: unknown;
@@ -168,7 +169,7 @@ describe('sshInstallCommand', () => {
   });
 
   it('emits {event:"error", code:"start-failed"} when remote start verification fails', async () => {
-    packAndInstall.mockResolvedValue(undefined);
+    directInstall.mockResolvedValue(undefined);
     startRemoteAgents.mockResolvedValue([
       { host: { name: 'demo' }, success: false, message: 'Agent process not found after start' },
     ]);
@@ -212,11 +213,11 @@ describe('sshInstallCommand', () => {
     const errEvent = events.find((e) => e.event === 'error');
     expect(errEvent).toMatchObject({ event: 'error', code: 'auth-required' });
     expect(String(thrown)).toContain('__exit:1');
-    expect(packAndInstall).not.toHaveBeenCalled();
+    expect(directInstall).not.toHaveBeenCalled();
   });
 
   it('emits {event:"error", code:"start-failed"} when startRemoteAgents itself throws after install completes', async () => {
-    packAndInstall.mockResolvedValue(undefined);
+    directInstall.mockResolvedValue(undefined);
     startRemoteAgents.mockRejectedValue(new Error('connection lost during verify'));
 
     const cap = captureStdout();
@@ -237,7 +238,7 @@ describe('sshInstallCommand', () => {
   });
 
   it('trims whitespace on the host alias', async () => {
-    packAndInstall.mockResolvedValue(undefined);
+    directInstall.mockResolvedValue(undefined);
     startRemoteAgents.mockResolvedValue([{ host: { name: 'demo' }, success: true, message: 'ok' }]);
 
     const cap = captureStdout();

--- a/src/commands/ssh-install.ts
+++ b/src/commands/ssh-install.ts
@@ -31,7 +31,7 @@ import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { discoverRemoteHosts } from '../lib/ssh-discovery.js';
 import {
-  packAndInstall,
+  directInstall,
   startRemoteAgents,
   buildSshArgs,
   type InstallOptions,
@@ -212,10 +212,10 @@ export async function sshInstallCommand(opts: SshInstallOptions): Promise<void> 
   };
 
   try {
-    await packAndInstall(installOptions, (msg) => {
-      // packAndInstall's progress messages are already human-readable.
-      // We classify them into stable step names so consumers can render
-      // a fixed progress bar without parsing free text.
+    await directInstall(installOptions, (msg) => {
+      // directInstall's progress messages are human-readable. We classify
+      // them into stable step names so consumers can render a fixed
+      // progress bar without parsing free text.
       emit({ event: 'step', name: classifyInstallStep(msg), message: msg });
     });
   } catch (err) {
@@ -263,11 +263,11 @@ export async function sshInstallCommand(opts: SshInstallOptions): Promise<void> 
 
 function classifyInstallStep(msg: string): string {
   const m = msg.toLowerCase();
-  if (m.startsWith('packing')) return 'pack';
-  if (m.startsWith('copying')) return 'upload';
-  if (m.startsWith('installing')) return 'install';
-  if (m.startsWith('running setup')) return 'configure';
-  if (m.startsWith('configuring tokens')) return 'configure';
+  if (m.startsWith('locating node')) return 'detect-node';
+  if (m.startsWith('preparing')) return 'prepare';
+  if (m.startsWith('uploading')) return 'upload';
+  if (m.startsWith('installing wrappers')) return 'install';
+  if (m.startsWith('configuring')) return 'configure';
   if (m.startsWith('done')) return 'install-done';
   return 'install';
 }

--- a/src/lib/ssh-installer.ts
+++ b/src/lib/ssh-installer.ts
@@ -9,9 +9,11 @@
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { networkInterfaces, homedir } from 'node:os';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import type { DiscoveredHost } from '../types.js';
 
@@ -393,6 +395,172 @@ export async function packAndInstall(
 }
 
 // ============================================================================
+// Direct install — SCP bundles + wrapper, no remote npm
+// ============================================================================
+
+/**
+ * Discover the absolute path to `node` on the remote, sourcing the user's
+ * login shell so PATH includes nvm/asdf/Homebrew/~/.local etc. Returns null
+ * if Node isn't available at all.
+ *
+ * The remote BatchMode SSH session uses a non-interactive non-login shell by
+ * default, so `which node` from within `sshExec` would miss anything not in
+ * /usr/bin or /usr/local/bin. `bash -lc` runs a login shell that sources the
+ * profile files, exposing the user's full PATH.
+ */
+async function findRemoteNodePath(host: DiscoveredHost): Promise<string | null> {
+  // Try bash first (most macOS/Linux). Fall back to sh for minimal systems
+  // (e.g. Alpine without bash). `command -v` is portable.
+  const cmd = `bash -lc 'command -v node' 2>/dev/null || sh -lc 'command -v node' 2>/dev/null || true`;
+  try {
+    const { stdout } = await sshExec(host, cmd);
+    const path = stdout.trim().split('\n').pop()?.trim() ?? '';
+    return path.length > 0 ? path : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the local paths to the bundled astro-agent.mjs and astro-cli.mjs
+ * files. Two install contexts:
+ *
+ *   1. Bundled inside an Electron app: both files are siblings in
+ *      ~/.astro/bin/ (or wherever the user installed them). The currently-
+ *      running file IS astro-agent (with or without .mjs extension).
+ *   2. npx @astroanywhere/agent: the agent is installed as an npm package;
+ *      the CLI is a separate npm package. Resolve via require.resolve.
+ *
+ * Throws with an actionable error if neither path resolves.
+ */
+function resolveLocalBundlePaths(): { agentMjs: string; cliMjs: string } {
+  const agentMjs = fileURLToPath(import.meta.url);
+  const dir = dirname(agentMjs);
+
+  // Sibling-bundle case: try common names with and without extension.
+  for (const name of ['astro-cli.mjs', 'astro-cli', 'astro-cli.cmd']) {
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) {
+      return { agentMjs, cliMjs: candidate };
+    }
+  }
+
+  // npm-package case: resolve @astroanywhere/cli via the agent-runner's
+  // module resolution.
+  try {
+    const req = createRequire(import.meta.url);
+    const cliMjs = req.resolve('@astroanywhere/cli/dist/cli.js');
+    return { agentMjs, cliMjs };
+  } catch {
+    throw new Error(
+      'Could not locate astro-cli bundle. Expected a sibling file in the same directory as astro-agent, or @astroanywhere/cli installed as a dependency.',
+    );
+  }
+}
+
+/** SCP a local file to a remote path, using ControlMaster if available. */
+async function scpFile(
+  host: DiscoveredHost,
+  localPath: string,
+  remotePath: string,
+): Promise<void> {
+  const args = buildScpArgs(host, localPath, remotePath);
+  await execFile('scp', args, { timeout: 120_000 });
+}
+
+/**
+ * Pipe a string to a file on the remote via stdin (avoids exposing tokens
+ * in process arguments). The remote shell uses `cat > <path>` to write.
+ */
+async function pipeToRemoteFile(
+  host: DiscoveredHost,
+  remotePath: string,
+  contents: string,
+  opts: { mode?: string } = {},
+): Promise<void> {
+  const chmod = opts.mode ? `chmod ${opts.mode} ${remotePath} && ` : '';
+  const cmd = `cat > ${remotePath} && ${chmod}true`;
+  const args = buildSshArgs(host, cmd);
+  return new Promise<void>((resolve, reject) => {
+    const child = execFileCb('ssh', args, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+    child.stdin?.write(contents);
+    child.stdin?.end();
+  });
+}
+
+/**
+ * Direct-install path: SCP bundled .mjs files + write wrapper scripts that
+ * hardcode the discovered remote Node path. No `npm install`, no remote
+ * `astro-agent setup --skip-auth`, no shell-PATH dependence at runtime.
+ *
+ * Steps:
+ *   1. Discover remote node via login shell
+ *   2. mkdir -p ~/.astro/bin ~/.astro/logs on remote
+ *   3. pkill any existing agent (always, per the always-stop-and-restart rule)
+ *   4. SCP astro-agent.mjs + astro-cli.mjs
+ *   5. Write wrapper scripts that exec the discovered node path
+ *   6. chmod +x on all four files
+ *   7. Pipe config.json (with all tokens) directly via stdin
+ *
+ * Compatible with InstallOptions for drop-in replacement of packAndInstall.
+ */
+export async function directInstall(
+  opts: InstallOptions,
+  onProgress?: (msg: string) => void,
+): Promise<void> {
+  const { host, apiUrl, relayUrl, accessToken, refreshToken, wsToken, machineId } = opts;
+  const log = onProgress ?? (() => {});
+
+  // 1. Find Node on the remote.
+  log(`Locating node on ${host.name}...`);
+  const nodePath = await findRemoteNodePath(host);
+  if (!nodePath) {
+    throw new Error(
+      `Node.js not found on ${host.name}. Install Node 18+ on the remote (e.g. via nvm, Homebrew, or your package manager) and retry.`,
+    );
+  }
+
+  // 2. Resolve local bundles.
+  const { agentMjs, cliMjs } = resolveLocalBundlePaths();
+
+  // 3. Prepare remote layout + always-stop-and-restart.
+  log(`Preparing ~/.astro on ${host.name}...`);
+  await sshExec(host, 'mkdir -p $HOME/.astro/bin $HOME/.astro/logs');
+  await sshExec(host, 'pkill -f "[a]stro-agent start" 2>/dev/null || true').catch(() => {});
+  await new Promise((r) => setTimeout(r, 500));
+
+  // 4. SCP the bundles.
+  log(`Uploading bundles to ${host.name}...`);
+  await scpFile(host, agentMjs, '$HOME/.astro/bin/astro-agent.mjs');
+  await scpFile(host, cliMjs, '$HOME/.astro/bin/astro-cli.mjs');
+
+  // 5. Wrapper scripts that pin the discovered node path.
+  log(`Installing wrappers on ${host.name}...`);
+  const agentWrapper = `#!/bin/sh\nexec ${nodePath} "$HOME/.astro/bin/astro-agent.mjs" "$@"\n`;
+  const cliWrapper = `#!/bin/sh\nexec ${nodePath} "$HOME/.astro/bin/astro-cli.mjs" "$@"\n`;
+  await pipeToRemoteFile(host, '$HOME/.astro/bin/astro-agent', agentWrapper, { mode: '755' });
+  await pipeToRemoteFile(host, '$HOME/.astro/bin/astro-cli', cliWrapper, { mode: '755' });
+
+  // 6. Pipe config.json with all tokens.
+  log(`Configuring ${host.name}...`);
+  const config = JSON.stringify({
+    apiUrl,
+    relayUrl,
+    accessToken,
+    refreshToken,
+    wsToken,
+    machineId,
+    setupCompleted: true,
+  });
+  await pipeToRemoteFile(host, '$HOME/.astro/config.json', config, { mode: '600' });
+
+  log(`Done — ${host.name} is configured`);
+}
+
+// ============================================================================
 // SSH / SCP helpers
 // ============================================================================
 
@@ -498,8 +666,9 @@ export async function startRemoteAgents(
     await new Promise((r) => setTimeout(r, 1000));
 
     // 2. Build start command with forwarded options
-    // Use full path to avoid PATH resolution issues across different shells (zsh, bash)
-    const agentBin = '$HOME/.local/bin/astro-agent';
+    // Use the wrapper script written by directInstall — it hardcodes the
+    // discovered node path so it works regardless of the SSH session's PATH.
+    const agentBin = '$HOME/.astro/bin/astro-agent';
     const flags: string[] = ['--foreground'];
     if (options.maxTasks) flags.push(`--max-tasks ${options.maxTasks}`);
     if (options.logLevel) flags.push(`--log-level ${options.logLevel}`);
@@ -510,7 +679,7 @@ export async function startRemoteAgents(
     try {
       await sshExec(
         host,
-        `export PATH="$HOME/.local/bin:$PATH" && mkdir -p $HOME/.astro/logs && nohup ${startCmd} > $HOME/.astro/logs/agent-runner.log 2>&1 & disown`,
+        `mkdir -p $HOME/.astro/logs && nohup ${startCmd} > $HOME/.astro/logs/agent-runner.log 2>&1 & disown`,
       );
     } catch {
       // nohup + & disown may cause SSH to exit with non-zero even when the


### PR DESCRIPTION
## What

Replace the `packAndInstall` path (npm pack → scp tarball → `npm install -g` on remote) with `directInstall`: SCP the bundled .mjs files directly + write small wrapper scripts that hardcode the discovered remote node path.

## Why

Real-world failure on v0.10.0: a real user hit `env: node: No such file or directory` on two SSH hosts (`pcssh`, `spssh`). Node was installed on both, but in nvm — not in the BatchMode SSH PATH. The npm-install path also requires outbound HTTPS to the npm registry from the remote, which is blocked on many clusters.

## How

```
1. ssh -lc 'command -v node'              ← discover node in user's full PATH
2. mkdir -p ~/.astro/bin ~/.astro/logs
3. pkill any running agent
4. scp astro-agent.mjs + astro-cli.mjs    ← bundles the desktop already has
5. write wrappers: #!/bin/sh\nexec <node> "$HOME/.astro/bin/<bundle>.mjs" "$@"
6. chmod +x both bundles + both wrappers
7. pipe config.json with all tokens via stdin (mode 600)
```

Wrapper hardcodes the absolute node path so subsequent `astro-agent start` over BatchMode SSH works regardless of the session's PATH.

## Bundle resolution

Two install contexts:

- **Sibling-bundled** (Electron desktop install): both .mjs files are siblings in `~/.astro/bin/`. Resolves via `dirname(import.meta.url)`.
- **npm-package** (`npx @astroanywhere/agent`): `@astroanywhere/cli` is a separate npm dep. Resolves via `createRequire(import.meta.url).resolve('@astroanywhere/cli/dist/cli.js')`.

## Other changes

`startRemoteAgents` invokes the new wrapper at `~/.astro/bin/astro-agent` instead of `$HOME/.local/bin/astro-agent` (the old npm-install location).

## Test plan

- [x] 1059 tests pass; 8 ssh-install tests updated for new step messages
- [x] `npx tsc --noEmit` clean
- [x] Smoke test: bogus host → valid `host-not-found` NDJSON
- [ ] CI green
- [ ] Manual: install onto a real SSH host that has nvm-installed node

## Out of scope

`packAndInstall` is left in the file for now (no consumers but doesn't hurt). Could be deleted in a follow-up.