### PR TITLE
fix(worktree-include): static import for ignore so esbuild can bundle it

### DIFF
--- a/src/lib/worktree-include.ts
+++ b/src/lib/worktree-include.ts
@@ -8,14 +8,23 @@
 
 import { readFile, readdir, copyFile, mkdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
-import { createRequire } from 'node:module';
+// Static import so esbuild can bundle the module inline. The previous
+// createRequire('ignore') pattern left it as a runtime require, which
+// fails when the bundled .mjs ships without an adjacent node_modules/.
+//
+// `ignore` is a CJS module exporting a callable function with an
+// attached namespace. Under `module: "NodeNext"` TypeScript merges
+// the function and namespace into a single namespace type, so the
+// default import isn't typed as callable. The runtime value IS the
+// factory function — cast through unknown to tell TS.
+import ignoreImport from 'ignore';
 
-const require = createRequire(import.meta.url);
-const ignore = require('ignore') as { default: (opts?: object) => Ignore };
 type Ignore = {
   add(patterns: string | readonly string[]): Ignore;
   ignores(pathname: string): boolean;
 };
+type IgnoreFactory = (options?: object) => Ignore;
+const ignoreLib = ignoreImport as unknown as IgnoreFactory;
 
 export interface WorktreeIncludeOptions {
   gitRoot: string;
@@ -38,8 +47,8 @@ export async function applyWorktreeInclude({
     return; // No .gitignore — nothing would be both included and ignored
   }
 
-  const includeMatcher = ignore.default().add(includeContent);
-  const ignoreMatcher = ignore.default().add(gitignoreContent);
+  const includeMatcher = ignoreLib().add(includeContent);
+  const ignoreMatcher = ignoreLib().add(gitignoreContent);
 
   const filesToCopy = await walkAndMatch(gitRoot, includeMatcher, ignoreMatcher);
 


### PR DESCRIPTION
## Summary

The desktop Electron app crashes within seconds of starting the bundled `astro-agent.mjs` with:

```
Error: Cannot find module 'ignore'
Require stack:
- /Users/$USER/.astro/bin/astro-agent
```

Surfaced in the UI as a generic `agent exited within 5s: code=1 signal=-` because the orchestrator wasn't appending stderr (the parent astro repo has a separate fix for that — [astro#1393](https://github.com/fuxialexander/astro/pull/1393)).

### Root cause

`src/lib/worktree-include.ts:11-14` used a runtime `createRequire('ignore')` pattern:

```ts
import { createRequire } from 'node:module';
const require = createRequire(import.meta.url);
const ignore = require('ignore') as { default: (opts?: object) => Ignore };
```

esbuild can't statically analyze `createRequire`-style requires. When the parent astro repo bundles `@astroanywhere/agent` into a single `.mjs` for shipment with the desktop app (`electron/resources/binaries/astro-agent.mjs`), the `ignore` package is left as a runtime require — but the bundle ships standalone with no adjacent `node_modules/`, so the require fails at runtime.

### Fix

Replace with a static `import` so esbuild inlines the module:

```ts
import ignoreImport from 'ignore';

type IgnoreFactory = (options?: object) => Ignore;
const ignoreLib = ignoreImport as unknown as IgnoreFactory;
```

The cast through `unknown` is necessary because `ignore` is a CJS module exporting `module.exports = fn` with an attached namespace. Under `module: "NodeNext"` TypeScript collapses the function + namespace into a non-callable namespace type, even though the runtime value is callable.

## Verification

- `npm run build` passes
- Re-bundled the upstream astro repo with `npm run build:binaries:local` against this branch
- `node electron/resources/binaries/astro-agent.mjs --help` now runs cleanly (was crashing before)

## Test plan

- [x] `npm run build` passes
- [ ] After merge: cut a new agent-runner npm release; the bundled `astro-agent.mjs` shipped with the next astro Electron release will no longer crash on startup

## Related

- Parent repo PR: [fuxialexander/astro#1393](https://github.com/fuxialexander/astro/pull/1393) — improves agent-orchestrator's early-exit error to surface the actual stderr (so this kind of bundling failure is visible next time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)