### PR TITLE
Release: merge dev → main (worktree-include ignore bundling fix)

### DIFF
--- a/src/lib/worktree-include.ts
+++ b/src/lib/worktree-include.ts
@@ -8,14 +8,23 @@
 
 import { readFile, readdir, copyFile, mkdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
-import { createRequire } from 'node:module';
+// Static import so esbuild can bundle the module inline. The previous
+// createRequire('ignore') pattern left it as a runtime require, which
+// fails when the bundled .mjs ships without an adjacent node_modules/.
+//
+// `ignore` is a CJS module exporting a callable function with an
+// attached namespace. Under `module: "NodeNext"` TypeScript merges
+// the function and namespace into a single namespace type, so the
+// default import isn't typed as callable. The runtime value IS the
+// factory function — cast through unknown to tell TS.
+import ignoreImport from 'ignore';
 
-const require = createRequire(import.meta.url);
-const ignore = require('ignore') as { default: (opts?: object) => Ignore };
 type Ignore = {
   add(patterns: string | readonly string[]): Ignore;
   ignores(pathname: string): boolean;
 };
+type IgnoreFactory = (options?: object) => Ignore;
+const ignoreLib = ignoreImport as unknown as IgnoreFactory;
 
 export interface WorktreeIncludeOptions {
   gitRoot: string;
@@ -38,8 +47,8 @@ export async function applyWorktreeInclude({
     return; // No .gitignore — nothing would be both included and ignored
   }
 
-  const includeMatcher = ignore.default().add(includeContent);
-  const ignoreMatcher = ignore.default().add(gitignoreContent);
+  const includeMatcher = ignoreLib().add(includeContent);
+  const ignoreMatcher = ignoreLib().add(gitignoreContent);
 
   const filesToCopy = await walkAndMatch(gitRoot, includeMatcher, ignoreMatcher);
 


### PR DESCRIPTION
## Summary

Single-commit patch release: ship the static `import ignoreImport from 'ignore'` fix from PR #219 to `main` so it can be cut to NPM.

### What changed

- **fix(worktree-include): static import for ignore so esbuild can bundle it** ([#219](https://github.com/astro-anywhere/astro-agent/pull/219))
  - Replaces runtime `createRequire('ignore')` with a static ESM import + a typed cast
  - The runtime `createRequire` pattern left `ignore` as an unbundled require call. When the parent astro repo bundles `astro-agent.mjs` standalone for the desktop Electron app, the require failed at runtime with `Cannot find module 'ignore'` and crashed the agent within seconds of startup
  - Surfaced in the desktop UI as a generic `agent exited within 5s: code=1 signal=-`

---

## Release Flow

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#dbeafe', 'primaryBorderColor': '#93c5fd', 'primaryTextColor': '#1e293b', 'lineColor': '#64748b', 'textColor': '#334155', 'fontSize': '14px', 'fontFamily': 'Inter, -apple-system, BlinkMacSystemFont, sans-serif'}}}%%
flowchart LR
    classDef blue fill:#dbeafe,stroke:#93c5fd,color:#1e293b
    classDef green fill:#dcfce7,stroke:#86efac,color:#1e293b
    classDef amber fill:#fef3c7,stroke:#fcd34b,color:#1e293b

    A["dev"]:::blue --> B["this PR"]:::amber --> C["main"]:::green --> D["npm version patch"]:::blue --> E["GitHub Release"]:::blue --> F["NPM publish 0.11.1"]:::green
```

---

## Test Plan

- [x] `npm run build` passes on the dev branch
- [x] Re-bundled the parent astro repo with `npm run build:binaries:local` against this fix; `node electron/resources/binaries/astro-agent.mjs --help` now runs cleanly (was crashing before)
- [ ] After release: parent astro repo bumps submodule pointer, re-publishes desktop v0.0.28, agent runner starts without `Cannot find module 'ignore'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)